### PR TITLE
Change `{status|url}_locator` format

### DIFF
--- a/docs/resources/operation.md
+++ b/docs/resources/operation.md
@@ -56,12 +56,12 @@ resource "restful_operation" "register_rp" {
 Required:
 
 - `status` (Attributes) The expected status sentinels for each polling state. (see [below for nested schema](#nestedatt--poll--status))
-- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `<scope>[<path>]`, where `<scope>` can be either `header` or `body`, and the `<path>` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `<scope>.<path>`, where `<scope>` can be either `header` or `body`, and the `<path>` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
 
 Optional:
 
 - `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
-- `url_locator` (String) Specifies how to discover the polling url. The format is as `<k>[<v>]`, which can be one of `header[path]` (use the property at `path` in response header), `body[path]` (use the property at `path` in response body) or `exact[value]` (use the exact `value`). When absent, the resource's path is used for polling.
+- `url_locator` (String) Specifies how to discover the polling url. The format is as `<k>.<v>`, which can be one of `header.<path>` (use the property at `<path>` in response header), `body.<path>` (use the property at `<path>` in response body) or `exact.<value>` (use the exact `<value>`). When absent, the resource's path is used for polling.
 
 <a id="nestedatt--poll--status"></a>
 ### Nested Schema for `poll.status`

--- a/docs/resources/operation.md
+++ b/docs/resources/operation.md
@@ -56,12 +56,12 @@ resource "restful_operation" "register_rp" {
 Required:
 
 - `status` (Attributes) The expected status sentinels for each polling state. (see [below for nested schema](#nestedatt--poll--status))
-- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `<scope>.<path>`, where `<scope>` can be either `header` or `body`, and the `<path>` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
 
 Optional:
 
 - `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
-- `url_locator` (String) Specifies how to discover the polling url. The format is as `<k>.<v>`, which can be one of `header.<path>` (use the property at `<path>` in response header), `body.<path>` (use the property at `<path>` in response body) or `exact.<value>` (use the exact `<value>`). When absent, the resource's path is used for polling.
+- `url_locator` (String) Specifies how to discover the polling url. The format can be one of `header.path` (use the property at `path` in response header), `body.path` (use the property at `path` in response body) or `exact.value` (use the exact `value`). When absent, the resource's path is used for polling.
 
 <a id="nestedatt--poll--status"></a>
 ### Nested Schema for `poll.status`

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -70,12 +70,12 @@ resource "restful_resource" "rg" {
 Required:
 
 - `status` (Attributes) The expected status sentinels for each polling state. (see [below for nested schema](#nestedatt--poll_create--status))
-- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `<scope>[<path>]`, where `<scope>` can be either `header` or `body`, and the `<path>` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `<scope>.<path>`, where `<scope>` can be either `header` or `body`, and the `<path>` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
 
 Optional:
 
 - `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
-- `url_locator` (String) Specifies how to discover the polling url. The format is as `<k>[<v>]`, which can be one of `header[path]` (use the property at `path` in response header), `body[path]` (use the property at `path` in response body) or `exact[value]` (use the exact `value`). When absent, the resource's path is used for polling.
+- `url_locator` (String) Specifies how to discover the polling url. The format is as `<k>.<v>`, which can be one of `header.<path>` (use the property at `<path>` in response header), `body.<path>` (use the property at `<path>` in response body) or `exact.<value>` (use the exact `<value>`). When absent, the resource's path is used for polling.
 
 <a id="nestedatt--poll_create--status"></a>
 ### Nested Schema for `poll_create.status`
@@ -96,12 +96,12 @@ Optional:
 Required:
 
 - `status` (Attributes) The expected status sentinels for each polling state. (see [below for nested schema](#nestedatt--poll_delete--status))
-- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `<scope>[<path>]`, where `<scope>` can be either `header` or `body`, and the `<path>` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `<scope>.<path>`, where `<scope>` can be either `header` or `body`, and the `<path>` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
 
 Optional:
 
 - `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
-- `url_locator` (String) Specifies how to discover the polling url. The format is as `<k>[<v>]`, which can be one of `header[path]` (use the property at `path` in response header), `body[path]` (use the property at `path` in response body) or `exact[value]` (use the exact `value`). When absent, the resource's path is used for polling.
+- `url_locator` (String) Specifies how to discover the polling url. The format is as `<k>.<v>`, which can be one of `header.<path>` (use the property at `<path>` in response header), `body.<path>` (use the property at `<path>` in response body) or `exact.<value>` (use the exact `<value>`). When absent, the resource's path is used for polling.
 
 <a id="nestedatt--poll_delete--status"></a>
 ### Nested Schema for `poll_delete.status`
@@ -122,12 +122,12 @@ Optional:
 Required:
 
 - `status` (Attributes) The expected status sentinels for each polling state. (see [below for nested schema](#nestedatt--poll_update--status))
-- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `<scope>[<path>]`, where `<scope>` can be either `header` or `body`, and the `<path>` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `<scope>.<path>`, where `<scope>` can be either `header` or `body`, and the `<path>` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
 
 Optional:
 
 - `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
-- `url_locator` (String) Specifies how to discover the polling url. The format is as `<k>[<v>]`, which can be one of `header[path]` (use the property at `path` in response header), `body[path]` (use the property at `path` in response body) or `exact[value]` (use the exact `value`). When absent, the resource's path is used for polling.
+- `url_locator` (String) Specifies how to discover the polling url. The format is as `<k>.<v>`, which can be one of `header.<path>` (use the property at `<path>` in response header), `body.<path>` (use the property at `<path>` in response body) or `exact.<value>` (use the exact `<value>`). When absent, the resource's path is used for polling.
 
 <a id="nestedatt--poll_update--status"></a>
 ### Nested Schema for `poll_update.status`

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -70,12 +70,12 @@ resource "restful_resource" "rg" {
 Required:
 
 - `status` (Attributes) The expected status sentinels for each polling state. (see [below for nested schema](#nestedatt--poll_create--status))
-- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `<scope>.<path>`, where `<scope>` can be either `header` or `body`, and the `<path>` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
 
 Optional:
 
 - `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
-- `url_locator` (String) Specifies how to discover the polling url. The format is as `<k>.<v>`, which can be one of `header.<path>` (use the property at `<path>` in response header), `body.<path>` (use the property at `<path>` in response body) or `exact.<value>` (use the exact `<value>`). When absent, the resource's path is used for polling.
+- `url_locator` (String) Specifies how to discover the polling url. The format can be one of `header.path` (use the property at `path` in response header), `body.path` (use the property at `path` in response body) or `exact.value` (use the exact `value`). When absent, the resource's path is used for polling.
 
 <a id="nestedatt--poll_create--status"></a>
 ### Nested Schema for `poll_create.status`
@@ -96,12 +96,12 @@ Optional:
 Required:
 
 - `status` (Attributes) The expected status sentinels for each polling state. (see [below for nested schema](#nestedatt--poll_delete--status))
-- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `<scope>.<path>`, where `<scope>` can be either `header` or `body`, and the `<path>` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
 
 Optional:
 
 - `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
-- `url_locator` (String) Specifies how to discover the polling url. The format is as `<k>.<v>`, which can be one of `header.<path>` (use the property at `<path>` in response header), `body.<path>` (use the property at `<path>` in response body) or `exact.<value>` (use the exact `<value>`). When absent, the resource's path is used for polling.
+- `url_locator` (String) Specifies how to discover the polling url. The format can be one of `header.path` (use the property at `path` in response header), `body.path` (use the property at `path` in response body) or `exact.value` (use the exact `value`). When absent, the resource's path is used for polling.
 
 <a id="nestedatt--poll_delete--status"></a>
 ### Nested Schema for `poll_delete.status`
@@ -122,12 +122,12 @@ Optional:
 Required:
 
 - `status` (Attributes) The expected status sentinels for each polling state. (see [below for nested schema](#nestedatt--poll_update--status))
-- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `<scope>.<path>`, where `<scope>` can be either `header` or `body`, and the `<path>` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
 
 Optional:
 
 - `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
-- `url_locator` (String) Specifies how to discover the polling url. The format is as `<k>.<v>`, which can be one of `header.<path>` (use the property at `<path>` in response header), `body.<path>` (use the property at `<path>` in response body) or `exact.<value>` (use the exact `<value>`). When absent, the resource's path is used for polling.
+- `url_locator` (String) Specifies how to discover the polling url. The format can be one of `header.path` (use the property at `path` in response header), `body.path` (use the property at `path` in response body) or `exact.value` (use the exact `value`). When absent, the resource's path is used for polling.
 
 <a id="nestedatt--poll_update--status"></a>
 ### Nested Schema for `poll_update.status`

--- a/internal/client/async.go
+++ b/internal/client/async.go
@@ -23,7 +23,7 @@ func (loc ExactLocator) locateValueInResp(_ resty.Response) string {
 	return string(loc)
 }
 func (loc ExactLocator) String() string {
-	return fmt.Sprintf(`exact[%s]`, string(loc))
+	return fmt.Sprintf(`exact.%s`, string(loc))
 }
 
 type HeaderLocator string
@@ -32,7 +32,7 @@ func (loc HeaderLocator) locateValueInResp(resp resty.Response) string {
 	return resp.Header().Get(string(loc))
 }
 func (loc HeaderLocator) String() string {
-	return fmt.Sprintf(`header[%s]`, string(loc))
+	return fmt.Sprintf(`header.%s`, string(loc))
 }
 
 type BodyLocator string
@@ -42,7 +42,7 @@ func (loc BodyLocator) locateValueInResp(resp resty.Response) string {
 	return result.String()
 }
 func (loc BodyLocator) String() string {
-	return fmt.Sprintf(`body[%s]`, string(loc))
+	return fmt.Sprintf(`body.%s`, string(loc))
 }
 
 type CodeLocator struct{}

--- a/internal/provider/api_option.go
+++ b/internal/provider/api_option.go
@@ -24,7 +24,7 @@ func parseLocator(locator string) (client.ValueLocator, error) {
 	if locator == "code" {
 		return client.CodeLocator{}, nil
 	}
-	p := regexp.MustCompile(`^(.+)\[(.+)\]$`)
+	p := regexp.MustCompile(`^(\w+)\.(.+)$`)
 	matches := p.FindAllStringSubmatch(locator, 1)
 	if len(matches) != 1 {
 		return nil, fmt.Errorf("invalid locator: %s", locator)

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -85,8 +85,8 @@ func pollAttribute(attr, s string) tfsdk.Attribute {
 		Optional:            true,
 		Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
 			"status_locator": {
-				Description:         "Specifies how to discover the status property. The format is either `code` or `<scope>.<path>`, where `<scope>` can be either `header` or `body`, and the `<path>` is using the gjson syntax.",
-				MarkdownDescription: "Specifies how to discover the status property. The format is either `code` or `<scope>.<path>`, where `<scope>` can be either `header` or `body`, and the `<path>` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).",
+				Description:         "Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the gjson syntax.",
+				MarkdownDescription: "Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).",
 				Required:            true,
 				Type:                types.StringType,
 			},
@@ -110,8 +110,8 @@ func pollAttribute(attr, s string) tfsdk.Attribute {
 				}),
 			},
 			"url_locator": {
-				Description:         "Specifies how to discover the polling url. The format is as `<k>.<v>`, which can be one of `header.<path>` (use the property at `<path>` in response header), `body.<path>` (use the property at `<path>` in response body) or `exact.<value>` (use the exact `<value>`). When absent, the resource's path is used for polling.",
-				MarkdownDescription: "Specifies how to discover the polling url. The format is as `<k>.<v>`, which can be one of `header.<path>` (use the property at `<path>` in response header), `body.<path>` (use the property at `<path>` in response body) or `exact.<value>` (use the exact `<value>`). When absent, the resource's path is used for polling.",
+				Description:         "Specifies how to discover the polling url. The format can be one of `header.path` (use the property at `path` in response header), `body.path` (use the property at `path` in response body) or `exact.value` (use the exact `value`). When absent, the resource's path is used for polling.",
+				MarkdownDescription: "Specifies how to discover the polling url. The format can be one of `header.path` (use the property at `path` in response header), `body.path` (use the property at `path` in response body) or `exact.value` (use the exact `value`). When absent, the resource's path is used for polling.",
 				Optional:            true,
 				Type:                types.StringType,
 			},

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -85,8 +85,8 @@ func pollAttribute(attr, s string) tfsdk.Attribute {
 		Optional:            true,
 		Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
 			"status_locator": {
-				Description:         "Specifies how to discover the status property. The format is either `code` or `<scope>[<path>]`, where `<scope>` can be either `header` or `body`, and the `<path>` is using the gjson syntax.",
-				MarkdownDescription: "Specifies how to discover the status property. The format is either `code` or `<scope>[<path>]`, where `<scope>` can be either `header` or `body`, and the `<path>` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).",
+				Description:         "Specifies how to discover the status property. The format is either `code` or `<scope>.<path>`, where `<scope>` can be either `header` or `body`, and the `<path>` is using the gjson syntax.",
+				MarkdownDescription: "Specifies how to discover the status property. The format is either `code` or `<scope>.<path>`, where `<scope>` can be either `header` or `body`, and the `<path>` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).",
 				Required:            true,
 				Type:                types.StringType,
 			},
@@ -110,8 +110,8 @@ func pollAttribute(attr, s string) tfsdk.Attribute {
 				}),
 			},
 			"url_locator": {
-				Description:         "Specifies how to discover the polling url. The format is as `<k>[<v>]`, which can be one of `header[path]` (use the property at `path` in response header), `body[path]` (use the property at `path` in response body) or `exact[value]` (use the exact `value`). When absent, the resource's path is used for polling.",
-				MarkdownDescription: "Specifies how to discover the polling url. The format is as `<k>[<v>]`, which can be one of `header[path]` (use the property at `path` in response header), `body[path]` (use the property at `path` in response body) or `exact[value]` (use the exact `value`). When absent, the resource's path is used for polling.",
+				Description:         "Specifies how to discover the polling url. The format is as `<k>.<v>`, which can be one of `header.<path>` (use the property at `<path>` in response header), `body.<path>` (use the property at `<path>` in response body) or `exact.<value>` (use the exact `<value>`). When absent, the resource's path is used for polling.",
+				MarkdownDescription: "Specifies how to discover the polling url. The format is as `<k>.<v>`, which can be one of `header.<path>` (use the property at `<path>` in response header), `body.<path>` (use the property at `<path>` in response body) or `exact.<value>` (use the exact `<value>`). When absent, the resource's path is used for polling.",
 				Optional:            true,
 				Type:                types.StringType,
 			},

--- a/internal/provider/resource_azure_test.go
+++ b/internal/provider/resource_azure_test.go
@@ -292,7 +292,7 @@ resource "restful_resource" "test" {
       success = "200"
       pending = ["202"]
     }
-    url_locator = "header[location]"
+    url_locator = "header.location"
   }
 }
 `, d.url, d.clientId, d.clientSecret, d.tenantId, d.subscriptionId, d.rd)
@@ -331,7 +331,7 @@ resource "restful_resource" "test" {
       success = "200"
       pending = ["202"]
     }
-    url_locator = "header[location]"
+    url_locator = "header.location"
   }
 }
 `, d.url, d.clientId, d.clientSecret, d.tenantId, d.subscriptionId, d.rd)
@@ -370,7 +370,7 @@ resource "restful_resource" "test" {
       success = "200"
       pending = ["202"]
     }
-    url_locator = "header[location]"
+    url_locator = "header.location"
   }
 }
 `, d.url, d.clientId, d.clientSecret, d.tenantId, d.subscriptionId, d.rd, d.subscriptionId, d.rd)
@@ -412,7 +412,7 @@ resource "restful_resource" "test" {
       success = "200"
       pending = ["202"]
     }
-    url_locator = "header[location]"
+    url_locator = "header.location"
   }
 }
 `, d.url, d.clientId, d.clientSecret, d.tenantId, d.subscriptionId, d.rd, d.subscriptionId, d.rd)
@@ -512,7 +512,7 @@ resource "restful_resource" "rg" {
       success = "200"
       pending = ["202"]
     }
-    url_locator = "header[location]"
+    url_locator = "header.location"
   }
 }
 
@@ -525,12 +525,12 @@ func (d azureData) vnet() string {
 
 locals {
   vnet_poll = {
-    status_locator = "body[status]"
+    status_locator = "body.status"
     status = {
       success = "Succeeded"
       pending = ["Pending"]
     }
-    url_locator = "header[azure-asyncoperation]"
+    url_locator = "header.azure-asyncoperation"
   }
 }
 
@@ -576,12 +576,12 @@ func (d azureData) vnet_update() string {
 
 locals {
   vnet_poll = {
-    status_locator = "body[status]"
+    status_locator = "body.status"
     status = {
       success = "Succeeded"
       pending = ["Pending"]
     }
-    url_locator = "header[azure-asyncoperation]"
+    url_locator = "header.azure-asyncoperation"
   }
 }
 
@@ -661,14 +661,14 @@ resource "restful_resource" "test" {
   }
 
   poll_create = {
-    status_locator = "body[properties.provisioningState]"
+    status_locator = "body.properties.provisioningState"
     status = {
       success = "Succeeded"
       pending = ["Updating"]
     }
   }
   poll_update = {
-    status_locator = "body[properties.provisioningState]"
+    status_locator = "body.properties.provisioningState"
     status = {
       success = "Succeeded"
       pending = ["Updating"]
@@ -719,14 +719,14 @@ resource "restful_resource" "test" {
   }
 
   poll_create = {
-    status_locator = "body[properties.provisioningState]"
+    status_locator = "body.properties.provisioningState"
     status = {
       success = "Succeeded"
       pending = ["Updating"]
     }
   }
   poll_update = {
-    status_locator = "body[properties.provisioningState]"
+    status_locator = "body.properties.provisioningState"
     status = {
       success = "Succeeded"
       pending = ["Updating"]
@@ -781,8 +781,8 @@ resource "restful_operation" "test" {
   }
   method = "POST"
   poll = {
-	url_locator = "exact[/subscriptions/%[5]s/providers/%[6]s?api-version=2014-04-01-preview]"
-    status_locator = "body[registrationState]"
+	url_locator = "exact./subscriptions/%[5]s/providers/%[6]s?api-version=2014-04-01-preview"
+    status_locator = "body.registrationState"
     status = {
       success = "Registered"
       pending = ["Registering"]
@@ -813,8 +813,8 @@ resource "restful_operation" "test" {
   }
   method = "POST"
   poll = {
-	url_locator = "exact[/subscriptions/%[5]s/providers/%[6]s?api-version=2014-04-01-preview]"
-    status_locator = "body[registrationState]"
+	url_locator = "exact./subscriptions/%[5]s/providers/%[6]s?api-version=2014-04-01-preview"
+    status_locator = "body.registrationState"
     status = {
       success = "Unregistered"
       pending = ["Unregistering"]


### PR DESCRIPTION
Change the syntax of `status_locator` and `url_locator` from `scope[path]` to `scope.path`. This is to be consistent as the format used in `xxx_path` when enclosed in `$()` or `#()` (e.g. `$(body.path)`.