### PR TITLE
Don't mark the overridable attributes as O+C, but optional only

### DIFF
--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -45,21 +45,18 @@ func (d *DataSource) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostic
 				MarkdownDescription: "The query parameters that are applied to each request. This overrides the `query` set in the provider block.",
 				Type:                types.MapType{ElemType: types.ListType{ElemType: types.StringType}},
 				Optional:            true,
-				Computed:            true,
 			},
 			"header": {
 				Description:         "The header parameters that are applied to each request. This overrides the `header` set in the provider block.",
 				MarkdownDescription: "The header parameters that are applied to each request. This overrides the `header` set in the provider block.",
 				Type:                types.MapType{ElemType: types.StringType},
 				Optional:            true,
-				Computed:            true,
 			},
 			"selector": {
 				Description:         "A selector in gjson query syntax, that is used when `id` represents a collection of resources, to select exactly one member resource of from it",
 				MarkdownDescription: "A selector in [gjson query syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md#queries), that is used when `id` represents a collection of resources, to select exactly one member resource of from it",
 				Type:                types.StringType,
 				Optional:            true,
-				Computed:            true,
 			},
 			"output": {
 				Description:         "The response body after reading the resource.",
@@ -134,8 +131,8 @@ func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 
 	state := dataSourceData{
 		ID:       config.ID,
-		Query:    opt.Query.ToTFValue(),
-		Header:   opt.Header.ToTFValue(),
+		Query:    config.Query,
+		Header:   config.Header,
 		Selector: config.Selector,
 		Output:   types.StringValue(string(b)),
 	}

--- a/internal/provider/data_source_jsonserver_test.go
+++ b/internal/provider/data_source_jsonserver_test.go
@@ -57,7 +57,7 @@ resource "restful_resource" "test" {
   body = jsonencode({
   	foo = "bar"
 })
-  name_path = "id"
+  read_path = "$(path)/$(body.id)"
 }
 
 data "restful_resource" "test" {
@@ -78,7 +78,7 @@ resource "restful_resource" "test" {
   body = jsonencode({
   	foo = "bar"
 })
-  name_path = "id"
+  read_path = "$(path)/$(body.id)"
 }
 
 data "restful_resource" "test" {

--- a/internal/provider/operation_resource.go
+++ b/internal/provider/operation_resource.go
@@ -81,14 +81,12 @@ func (r *OperationResource) GetSchema(_ context.Context) (tfsdk.Schema, diag.Dia
 				MarkdownDescription: "The query parameters that are applied to each request. This overrides the `query` set in the provider block.",
 				Type:                types.MapType{ElemType: types.ListType{ElemType: types.StringType}},
 				Optional:            true,
-				Computed:            true,
 			},
 			"header": {
 				Description:         "The header parameters that are applied to each request. This overrides the `header` set in the provider block.",
 				MarkdownDescription: "The header parameters that are applied to each request. This overrides the `header` set in the provider block.",
 				Type:                types.MapType{ElemType: types.StringType},
 				Optional:            true,
-				Computed:            true,
 			},
 			"poll": pollAttribute("poll", "API"),
 			"output": {
@@ -190,10 +188,6 @@ func (r *OperationResource) createOrUpdate(ctx context.Context, tfplan tfsdk.Pla
 			return
 		}
 	}
-
-	// Set overridable attributes from option to state
-	plan.Query = opt.Query.ToTFValue()
-	plan.Header = opt.Header.ToTFValue()
 
 	// Set resource ID to state
 	plan.ID = types.StringValue(resourceId)

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -189,7 +189,6 @@ func (r *Resource) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics)
 				MarkdownDescription: "The method used to create the resource. Possible values are `PUT` and `POST`. This overrides the `create_method` set in the provider block (defaults to POST).",
 				Type:                types.StringType,
 				Optional:            true,
-				Computed:            true,
 				Validators: []tfsdk.AttributeValidator{
 					stringvalidator.OneOf("PUT", "POST"),
 				},
@@ -199,7 +198,6 @@ func (r *Resource) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics)
 				MarkdownDescription: "The method used to update the resource. Possible values are `PUT` and `PATCH`. This overrides the `update_method` set in the provider block (defaults to PUT).",
 				Type:                types.StringType,
 				Optional:            true,
-				Computed:            true,
 				Validators: []tfsdk.AttributeValidator{
 					stringvalidator.OneOf("PUT", "PATCH"),
 				},
@@ -209,7 +207,6 @@ func (r *Resource) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics)
 				MarkdownDescription: "The method used to delete the resource. Possible values are `DELETE` and `POST`. This overrides the `delete_method` set in the provider block (defaults to DELETE).",
 				Type:                types.StringType,
 				Optional:            true,
-				Computed:            true,
 				Validators: []tfsdk.AttributeValidator{
 					stringvalidator.OneOf("DELETE", "POST"),
 				},
@@ -219,21 +216,18 @@ func (r *Resource) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics)
 				MarkdownDescription: "Whether to use a JSON Merge Patch as the request body in the PATCH update? This is only effective when `update_method` is set to `PATCH`. This overrides the `merge_patch_disabled` set in the provider block (defaults to `false`).",
 				Type:                types.BoolType,
 				Optional:            true,
-				Computed:            true,
 			},
 			"query": {
 				Description:         "The query parameters that are applied to each request. This overrides the `query` set in the provider block.",
 				MarkdownDescription: "The query parameters that are applied to each request. This overrides the `query` set in the provider block.",
 				Type:                types.MapType{ElemType: types.ListType{ElemType: types.StringType}},
 				Optional:            true,
-				Computed:            true,
 			},
 			"header": {
 				Description:         "The header parameters that are applied to each request. This overrides the `header` set in the provider block.",
 				MarkdownDescription: "The header parameters that are applied to each request. This overrides the `header` set in the provider block.",
 				Type:                types.MapType{ElemType: types.StringType},
 				Optional:            true,
-				Computed:            true,
 			},
 			"output": {
 				Description:         "The response body after reading the resource.",
@@ -393,24 +387,6 @@ func (r Resource) Create(ctx context.Context, req resource.CreateRequest, resp *
 		}
 	}
 
-	// Set the value for overridable (O+C) attributes in plan, which will affect read
-	plan.Query = opt.Query.ToTFValue()
-	plan.Header = opt.Header.ToTFValue()
-	// create_method is already resolved in the create opt here
-	plan.CreateMethod = types.StringValue(opt.Method)
-	// Since the update_method is O+C, it is unknown in the plan when not specified.
-	if plan.UpdateMethod.IsUnknown() {
-		plan.UpdateMethod = types.StringValue(r.p.apiOpt.UpdateMethod)
-	}
-	// Since the delete is O+C, it is unknown in the plan when not specified.
-	if plan.DeleteMethod.IsUnknown() {
-		plan.DeleteMethod = types.StringValue(r.p.apiOpt.DeleteMethod)
-	}
-	// Since the merge_patch_disabled is O+C, it is unknown in the plan when not specified.
-	if plan.MergePatchDisabled.IsUnknown() {
-		plan.MergePatchDisabled = types.BoolValue(r.p.apiOpt.MergePatchDisabled)
-	}
-
 	// Set resource ID
 	plan.ID = types.StringValue(resourceId)
 
@@ -524,34 +500,6 @@ func (r Resource) Read(ctx context.Context, req resource.ReadRequest, resp *reso
 	// Set body, which is modified during read.
 	state.Body = types.StringValue(string(body))
 
-	createMethod := r.p.apiOpt.CreateMethod
-	if state.CreateMethod.ValueString() != "" {
-		createMethod = state.CreateMethod.ValueString()
-	}
-
-	updateMethod := r.p.apiOpt.UpdateMethod
-	if state.UpdateMethod.ValueString() != "" {
-		updateMethod = state.UpdateMethod.ValueString()
-	}
-
-	deleteMethod := r.p.apiOpt.DeleteMethod
-	if state.DeleteMethod.ValueString() != "" {
-		deleteMethod = state.DeleteMethod.ValueString()
-	}
-
-	mergePatchDisabled := r.p.apiOpt.MergePatchDisabled
-	if !state.MergePatchDisabled.IsNull() {
-		mergePatchDisabled = state.MergePatchDisabled.ValueBool()
-	}
-
-	// Set overridable (O+C) attributes from option to state
-	state.Query = opt.Query.ToTFValue()
-	state.Header = opt.Header.ToTFValue()
-	state.CreateMethod = types.StringValue(createMethod)
-	state.UpdateMethod = types.StringValue(updateMethod)
-	state.DeleteMethod = types.StringValue(deleteMethod)
-	state.MergePatchDisabled = types.BoolValue(mergePatchDisabled)
-
 	// Set computed attributes
 	state.Output = types.StringValue(string(b))
 
@@ -646,22 +594,6 @@ func (r Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *
 			}
 		}
 	}
-
-	// Set the value for overridable (O+C) attributes in plan, which will affect read
-	plan.Query = opt.Query.ToTFValue()
-	plan.Header = opt.Header.ToTFValue()
-	// update_method is already resolved in the update opt here
-	plan.UpdateMethod = types.StringValue(opt.Method)
-	// Since the create_method is O+C, it is unknown in the plan when not specified.
-	if plan.CreateMethod.IsUnknown() {
-		plan.CreateMethod = types.StringValue(r.p.apiOpt.CreateMethod)
-	}
-	// Since the delete is O+C, it is unknown in the plan when not specified.
-	if plan.DeleteMethod.IsUnknown() {
-		plan.DeleteMethod = types.StringValue(r.p.apiOpt.DeleteMethod)
-	}
-	// merge_patch_disabled is already resolved in the update opt here
-	plan.MergePatchDisabled = types.BoolValue(opt.MergePatchDisabled)
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/resource_azure_test.go
+++ b/internal/provider/resource_azure_test.go
@@ -469,7 +469,6 @@ func (d azureData) vnetImportStateIdFunc(addr string) func(s *terraform.State) (
     "api-version": ["2021-05-01"]
   },
   "path": %[1]q,
-  "create_method": "PUT",
   "body": {
     "location": null,
     "properties": {
@@ -778,10 +777,12 @@ provider "restful" {
   base_url = %[1]q
   security = {
     oauth2 = {
-      client_id     = %[2]q
-      client_secret = %[3]q
-      token_url     = "https://login.microsoftonline.com/%[4]s/oauth2/v2.0/token"
-      scopes        = ["https://management.azure.com/.default"]
+	  client_credentials = {
+		  client_id     = %[2]q
+		  client_secret = %[3]q
+		  token_url     = "https://login.microsoftonline.com/%[4]s/oauth2/v2.0/token"
+		  scopes        = ["https://management.azure.com/.default"]
+	  }
     }
   }
 }


### PR DESCRIPTION
We don't have to always set a value for these attributes (e.g. `create_method`), as the information needed for the API operations are always available. So if an attribute is only provided at the provider level, that attribute is used for CRUD of the resource/data source, but the value is not set to the resource/data source's state, which makes the code a lot cleaner.

Another benefit of that is in this case, if another attribute of that resource changed (e.g. the `body`), the plan diff will show unnecessary noise telling users that those O+C and not yet set attribute (so they are regarded as C at this moment) as "known after apply". This will be avoided with this change.

Replaces #22.