### PR TITLE
Provider: Introduce `cookie_enabled` for enable/disable the cookie during API contracting

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -93,6 +93,7 @@ provider "restful" {
 
 ### Optional
 
+- `cookie_enabled` (Boolean) Save cookies during API contracting. Defaults to `false`.
 - `create_method` (String) The method used to create the resource. Possible values are `PUT` and `POST`. Defaults to `POST`.
 - `delete_method` (String) The method used to delete the resource. Possible values are `DELETE` and `POST`. Defaults to `DELETE`.
 - `header` (Map of String) The header parameters that are applied to each request.

--- a/internal/client/build_option.go
+++ b/internal/client/build_option.go
@@ -11,7 +11,8 @@ import (
 )
 
 type BuildOption struct {
-	Security securityOption
+	Security      securityOption
+	CookieEnabled bool
 }
 
 type securityOption interface {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -79,16 +79,16 @@ func New(ctx context.Context, baseURL string, opt *BuildOption) (*Client, error)
 	}
 
 	client := resty.New()
-	if !opt.CookieEnabled {
-		client.SetCookieJar(nil)
-	}
-
 	if opt.Security != nil {
 		var err error
 		client, err = opt.Security.newClient(ctx)
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if !opt.CookieEnabled {
+		client.SetCookieJar(nil)
 	}
 
 	if _, err := url.Parse(baseURL); err != nil {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -79,6 +79,10 @@ func New(ctx context.Context, baseURL string, opt *BuildOption) (*Client, error)
 	}
 
 	client := resty.New()
+	if !opt.CookieEnabled {
+		client.SetCookieJar(nil)
+	}
+
 	if opt.Security != nil {
 		var err error
 		client, err = opt.Security.newClient(ctx)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -38,6 +38,7 @@ type providerData struct {
 	MergePatchDisabled *bool               `tfsdk:"merge_patch_disabled"`
 	Query              map[string][]string `tfsdk:"query"`
 	Header             map[string]string   `tfsdk:"header"`
+	CookieEnabled      *bool               `tfsdk:"cookie_enabled"`
 }
 
 type securityData struct {
@@ -472,6 +473,11 @@ func (*Provider) Schema(ctx context.Context, req provider.SchemaRequest, resp *p
 				ElementType:         types.StringType,
 				Optional:            true,
 			},
+			"cookie_enabled": schema.BoolAttribute{
+				Description:         "Save cookies during API contracting. Defaults to `false`.",
+				MarkdownDescription: "Save cookies during API contracting. Defaults to `false`.",
+				Optional:            true,
+			},
 		},
 	}
 }
@@ -484,7 +490,12 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 		return
 	}
 
-	clientOpt := client.BuildOption{}
+	clientOpt := client.BuildOption{
+		CookieEnabled: false,
+	}
+	if config.CookieEnabled != nil {
+		clientOpt.CookieEnabled = *config.CookieEnabled
+	}
 	if sec := config.Security; sec != nil {
 		switch {
 		case sec.HTTP != nil:


### PR DESCRIPTION
This PR introduces a new attribute `cookie_enabled` at the provider block to allow users to disable (default)/enable the cookie during API contracting (the `resty.New()` create a client with cookiejar enabled).

Fix #27.