### PR TITLE
Defaults to use urlencoded when `xxx_path` expands with form `$(body.x.y.z)`

### DIFF
--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -45,9 +45,10 @@ resource "restful_resource" "rg" {
 
 ### Optional
 
+- `check_existance` (Boolean) Whether to check resource already existed? Defaults to `false`.
 - `create_method` (String) The method used to create the resource. Possible values are `PUT` and `POST`. This overrides the `create_method` set in the provider block (defaults to POST).
 - `delete_method` (String) The method used to delete the resource. Possible values are `DELETE` and `POST`. This overrides the `delete_method` set in the provider block (defaults to DELETE).
-- `delete_path` (String) The API path used to delete the resource. The `id` is used instead if `delete_path` is absent. The path can be string literal, or combined by followings: `$(path)` expanded to `path`, `$(body.x.y.z)` expands to the `x.y.z` property in API body, `#(body.id)` expands to the `id` property, with `base_url` prefix trimmed.
+- `delete_path` (String) The API path used to delete the resource. The `id` is used instead if `delete_path` is absent. The path can be string literal, or combined by followings: `$(path)` expanded to `path`, `$(body.x.y.z)` expands to the `x.y.z` property (urlencoded) in API body, `#(body.id)` expands to the `id` property, with `base_url` prefix trimmed.
 - `header` (Map of String) The header parameters that are applied to each request. This overrides the `header` set in the provider block.
 - `merge_patch_disabled` (Boolean) Whether to use a JSON Merge Patch as the request body in the PATCH update? This is only effective when `update_method` is set to `PATCH`. This overrides the `merge_patch_disabled` set in the provider block (defaults to `false`).
 - `poll_create` (Attributes) The polling option for the "Create" operation (see [below for nested schema](#nestedatt--poll_create))
@@ -58,9 +59,9 @@ resource "restful_resource" "rg" {
 - `precheck_update` (Attributes) The precheck that is prior to the "Update" operation. (see [below for nested schema](#nestedatt--precheck_update))
 - `query` (Map of List of String) The query parameters that are applied to each request. This overrides the `query` set in the provider block.
 - `read_body_locator` (String) Specifies how to locate the resource body in the read response. The format is `body.path`, where the `path` is using the gjson syntax[gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
-- `read_path` (String) The API path used to read the resource, which is used as the `id`. The `path` is used as the `id` instead if `read_path` is absent. The path can be string literal, or combined by followings: `$(path)` expanded to `path`, `$(body.x.y.z)` expands to the `x.y.z` property in API body, `#(body.id)` expands to the `id` property, with `base_url` prefix trimmed.
+- `read_path` (String) The API path used to read the resource, which is used as the `id`. The `path` is used as the `id` instead if `read_path` is absent. The path can be string literal, or combined by followings: `$(path)` expanded to `path`, `$(body.x.y.z)` expands to the `x.y.z` property (urlencoded) in API body, `#(body.id)` expands to the `id` property, with `base_url` prefix trimmed.
 - `update_method` (String) The method used to update the resource. Possible values are `PUT` and `PATCH`. This overrides the `update_method` set in the provider block (defaults to PUT).
-- `update_path` (String) The API path used to update the resource. The `id` is used instead if `update_path` is absent. The path can be string literal, or combined by followings: `$(path)` expanded to `path`, `$(body.x.y.z)` expands to the `x.y.z` property in API body, `#(body.id)` expands to the `id` property, with `base_url` prefix trimmed.
+- `update_path` (String) The API path used to update the resource. The `id` is used instead if `update_path` is absent. The path can be string literal, or combined by followings: `$(path)` expanded to `path`, `$(body.x.y.z)` expands to the `x.y.z` property (urlencoded) in API body, `#(body.id)` expands to the `id` property, with `base_url` prefix trimmed.
 - `write_only_attrs` (List of String) A list of paths (in [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md)) to the attributes that are only settable, but won't be read in GET response.
 
 ### Read-Only

--- a/internal/buildpath/path.go
+++ b/internal/buildpath/path.go
@@ -12,7 +12,7 @@ import (
 var (
 	// IdPattern matches against a full URL, which is meant to be prefix trimed by the server's base URL.
 	// This can be "#{body.x.y.z}".
-	IdPattern = regexp.MustCompile(`\#(\w*)\(([\w.]+)\)`)
+	IdPattern = regexp.MustCompile(`\#\(([\w.]+)\)`)
 
 	// ValuePattern matches against a normal string. This can be either "${path}", or "${body.x.y.z}"
 	ValuePattern = regexp.MustCompile(`\$(\w*)\(([\w.]+)\)`)
@@ -21,7 +21,7 @@ var (
 type PathFunc func(string) string
 
 var PathFuncs = map[string]PathFunc{
-	"urlencode": url.QueryEscape,
+	"plain": func(s string) string { return s },
 }
 
 func BuildPath(pattern string, baseURL, path string, body []byte) (string, error) {
@@ -29,14 +29,12 @@ func BuildPath(pattern string, baseURL, path string, body []byte) (string, error
 
 	matches := ValuePattern.FindAllStringSubmatch(out, -1)
 	for _, match := range matches {
-		f := func(s string) string {
-			return s
-		}
+		f := url.PathEscape
 		if fname := match[1]; fname != "" {
 			f = PathFuncs[fname]
 		}
 		if match[2] == "path" {
-			out = strings.ReplaceAll(out, match[0], f(path))
+			out = strings.ReplaceAll(out, match[0], path)
 			continue
 		}
 		if strings.HasPrefix(match[2], "body.") {
@@ -53,19 +51,13 @@ func BuildPath(pattern string, baseURL, path string, body []byte) (string, error
 
 	matches = IdPattern.FindAllStringSubmatch(out, -1)
 	for _, match := range matches {
-		f := func(s string) string {
-			return s
-		}
-		if fname := match[1]; fname != "" {
-			f = PathFuncs[fname]
-		}
-		if strings.HasPrefix(match[2], "body.") {
-			jsonPath := strings.TrimPrefix(match[2], "body.")
+		if strings.HasPrefix(match[1], "body.") {
+			jsonPath := strings.TrimPrefix(match[1], "body.")
 			prop := gjson.GetBytes(body, jsonPath)
 			if !prop.Exists() {
 				return "", fmt.Errorf("no property found at path %q in the body", jsonPath)
 			}
-			out = strings.ReplaceAll(out, match[0], f(strings.TrimPrefix(prop.String(), baseURL)))
+			out = strings.ReplaceAll(out, match[0], strings.TrimPrefix(prop.String(), baseURL))
 			continue
 		}
 		return "", fmt.Errorf("invalid match: %s", match[0])

--- a/internal/buildpath/path_test.go
+++ b/internal/buildpath/path_test.go
@@ -1,4 +1,4 @@
-package provider
+package buildpath
 
 import (
 	"testing"
@@ -34,6 +34,18 @@ func TestBuildPath(t *testing.T) {
 			path:    "collections",
 			body:    `{"name": "abc"}`,
 			expect:  "collections/abc",
+		},
+		{
+			name:    "Body value contains special chars",
+			pattern: "$(body.name)",
+			body:    `{"name": "a/b/c"}`,
+			expect:  `a%2Fb%2Fc`,
+		},
+		{
+			name:    "Body value contains special chars, but explictly plain",
+			pattern: "$plain(body.name)",
+			body:    `{"name": "a/b/c"}`,
+			expect:  `a/b/c`,
 		},
 		{
 			name:    "Body doesn't contain the expected property",

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -230,7 +230,7 @@ func pollAttribute(s string) schema.Attribute {
 }
 
 func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	const pathDescription = "The path can be string literal, or combined by followings: `$(path)` expanded to `path`, `$(body.x.y.z)` expands to the `x.y.z` property in API body, `#(body.id)` expands to the `id` property, with `base_url` prefix trimmed."
+	const pathDescription = "The path can be string literal, or combined by followings: `$(path)` expanded to `path`, `$(body.x.y.z)` expands to the `x.y.z` property (urlencoded) in API body, `#(body.id)` expands to the `id` property, with `base_url` prefix trimmed."
 	resp.Schema = schema.Schema{
 		Description:         "`restful_resource` manages a restful resource.",
 		MarkdownDescription: "`restful_resource` manages a restful resource.",
@@ -357,10 +357,6 @@ func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 				Description:         "Whether to check resource already existed? Defaults to `false`.",
 				MarkdownDescription: "Whether to check resource already existed? Defaults to `false`.",
 				Optional:            true,
-				Computed:            true,
-				PlanModifiers: []planmodifier.Bool{
-					myplanmodifier.DefaultAttribute(types.BoolValue(false)),
-				},
 			},
 			"output": schema.StringAttribute{
 				Description:         "The response body after reading the resource.",

--- a/internal/validator/string_is_path_builder.go
+++ b/internal/validator/string_is_path_builder.go
@@ -38,13 +38,13 @@ func (_ stringsIsPathBuilder) ValidateString(ctx context.Context, req validator.
 						fmt.Sprintf("unknown function: %s", fname),
 					)
 				}
-			}
-			if value != "path" && !strings.HasPrefix(value, "body.") {
-				return diag.NewAttributeErrorDiagnostic(
-					req.Path,
-					"Invalid String",
-					fmt.Sprintf("value isn't a path or a body reference"),
-				)
+				if !strings.HasPrefix(value, "body.") {
+					return diag.NewAttributeErrorDiagnostic(
+						req.Path,
+						"Invalid String",
+						fmt.Sprintf("value isn't a body reference"),
+					)
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
Defaults to use urlencoded when `xxx_path` expands with form `$(body.x.y.z)`.