### PR TITLE
`restful_resource` - Support `{read|create}_selector`

### DIFF
--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -47,6 +47,7 @@ resource "restful_resource" "rg" {
 
 - `check_existance` (Boolean) Whether to check resource already existed? Defaults to `false`.
 - `create_method` (String) The method used to create the resource. Possible values are `PUT` and `POST`. This overrides the `create_method` set in the provider block (defaults to POST).
+- `create_selector` (String) A selector in [gjson query syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md#queries) query syntax, that is used when create returns a collection of resources, to select exactly one member resource of from it. By default, the whole response body is used as the body.
 - `delete_method` (String) The method used to delete the resource. Possible values are `DELETE` and `POST`. This overrides the `delete_method` set in the provider block (defaults to DELETE).
 - `delete_path` (String) The API path used to delete the resource. The `id` is used instead if `delete_path` is absent. The path can be string literal, or combined by followings: `$(path)` expanded to `path`, `$(body.x.y.z)` expands to the `x.y.z` property (urlencoded) in API body, `#(body.id)` expands to the `id` property, with `base_url` prefix trimmed.
 - `header` (Map of String) The header parameters that are applied to each request. This overrides the `header` set in the provider block.
@@ -58,8 +59,8 @@ resource "restful_resource" "rg" {
 - `precheck_delete` (Attributes) The precheck that is prior to the "Delete" operation. (see [below for nested schema](#nestedatt--precheck_delete))
 - `precheck_update` (Attributes) The precheck that is prior to the "Update" operation. (see [below for nested schema](#nestedatt--precheck_update))
 - `query` (Map of List of String) The query parameters that are applied to each request. This overrides the `query` set in the provider block.
-- `read_body_locator` (String) Specifies how to locate the resource body in the read response. The format is `body.path`, where the `path` is using the gjson syntax[gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
 - `read_path` (String) The API path used to read the resource, which is used as the `id`. The `path` is used as the `id` instead if `read_path` is absent. The path can be string literal, or combined by followings: `$(path)` expanded to `path`, `$(body.x.y.z)` expands to the `x.y.z` property (urlencoded) in API body, `#(body.id)` expands to the `id` property, with `base_url` prefix trimmed.
+- `read_selector` (String) A selector in [gjson query syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md#queries) query syntax, that is used when read returns a collection of resources, to select exactly one member resource of from it. By default, the whole response body is used as the body.
 - `update_method` (String) The method used to update the resource. Possible values are `PUT`, `POST`, and `PATCH`. This overrides the `update_method` set in the provider block (defaults to PUT).
 - `update_path` (String) The API path used to update the resource. The `id` is used instead if `update_path` is absent. The path can be string literal, or combined by followings: `$(path)` expanded to `path`, `$(body.x.y.z)` expands to the `x.y.z` property (urlencoded) in API body, `#(body.id)` expands to the `id` property, with `base_url` prefix trimmed.
 - `write_only_attrs` (List of String) A list of paths (in [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md)) to the attributes that are only settable, but won't be read in GET response.

--- a/examples/usecases/feedly/main.tf
+++ b/examples/usecases/feedly/main.tf
@@ -1,0 +1,52 @@
+variable "token" {
+  type = string
+}
+
+terraform {
+  required_providers {
+    restful = {
+      source = "magodo/restful"
+    }
+  }
+}
+
+provider "restful" {
+  base_url = "https://cloud.feedly.com/v3"
+  security = {
+    http = {
+      token = {
+        token = var.token
+      }
+    }
+  }
+}
+
+locals {
+  feeds = toset([
+    "feed/https://arslan.io/index.xml",
+    "feed/http://dave.cheney.net/category/golang/feed",
+    "feed/https://jbd.dev/index.xml",
+  ])
+}
+
+resource "restful_resource" "collection_go" {
+  path          = "collections"
+  update_method = "POST"
+  read_path     = "$(path)/$(body.0.id)"
+  read_selector = "0"
+  body = jsonencode({
+    label = "Go"
+  })
+}
+
+resource "restful_resource" "feeds" {
+  for_each        = local.feeds
+  path            = "${restful_resource.collection_go.id}/feeds"
+  create_method   = "PUT"
+  create_selector = "#[feedId == \"${each.value}\"]"
+  read_path       = "feeds/$(body.id)"
+  delete_path     = "${restful_resource.collection_go.id}/feeds/$(body.id)"
+  body = jsonencode({
+    id = each.value
+  })
+}

--- a/examples/usecases/feedly/main.tf
+++ b/examples/usecases/feedly/main.tf
@@ -1,3 +1,4 @@
+# This needs to be run with "-parallelism=1", otherwise the "/feeds" might miss to add the feed to the collection. 
 variable "token" {
   type = string
 }

--- a/examples/usecases/spotify/main.tf
+++ b/examples/usecases/spotify/main.tf
@@ -1,0 +1,61 @@
+variable "token" {
+  type = string
+}
+
+terraform {
+  required_providers {
+    restful = {
+      source = "magodo/restful"
+    }
+  }
+}
+
+provider "restful" {
+  base_url = "https://api.spotify.com/v1"
+  security = {
+    http = {
+      token = {
+        token = var.token
+      }
+    }
+  }
+}
+
+data "restful_resource" "me" {
+  id = "/me"
+}
+
+resource "restful_resource" "playlist" {
+  path        = "/users/${jsondecode(data.restful_resource.me.output).id}/playlists"
+  read_path   = "/playlists/$(body.id)"
+  delete_path = "/playlists/$(body.id)/followers"
+  body = jsonencode({
+    name = "World Cup (by Terraform)"
+  })
+}
+
+locals {
+  my_favorite_tracks = {
+    "The Cup of Life" : "Ricky Martin",
+    "Wavin' Flag" : "K'NAAN",
+    "Waka Waka" : "Shakira",
+  }
+}
+
+data "restful_resource" "track" {
+  for_each = local.my_favorite_tracks
+  id       = "/search"
+  query = {
+    q     = ["${each.key}", "artist:${each.value}"]
+    type  = ["track"]
+    limit = [1]
+  }
+}
+
+resource "restful_operation" "add_tracks_to_playlist" {
+  path   = "${restful_resource.playlist.id}/tracks"
+  method = "PUT"
+  body = jsonencode({
+    uris = [for d in data.restful_resource.track : jsondecode(d.output).tracks.items[0].uri]
+  })
+}


### PR DESCRIPTION
`restful_resource` - Support `{read|create}_selector` to select the target body from the response of `create` or `read`, in case the response is an array of multiple bodies.

Example: https://github.com/magodo/terraform-provider-restful/compare/selector?expand=1#diff-e9322cb12ebc0a2b88c5fc27dadc0911801868fcfb0d31b4e74f39fd90a582e6R47