### PR TITLE
`poll_xxx`: Fix double urlencoding the URL and introduce the `query` attribute

### DIFF
--- a/internal/provider/operation_resource.go
+++ b/internal/provider/operation_resource.go
@@ -186,7 +186,7 @@ func (r *OperationResource) createOrUpdate(ctx context.Context, tfplan tfsdk.Pla
 			diagnostics.Append(diags...)
 			return
 		}
-		opt, diags := r.p.apiOpt.ForPoll(ctx, opt.Header, d)
+		opt, diags := r.p.apiOpt.ForPoll(ctx, opt.Header, opt.Query, d)
 		if diags.HasError() {
 			diagnostics.Append(diags...)
 			return
@@ -194,7 +194,7 @@ func (r *OperationResource) createOrUpdate(ctx context.Context, tfplan tfsdk.Pla
 		if opt.UrlLocator == nil {
 			// Update the request URL to pointing to the resource path, which is mainly for resources whose create method is POST.
 			// As it will be used to poll the resource status.
-			response.Request.RawRequest.URL.Path, _ = url.JoinPath(r.p.apiOpt.BaseURL.String(), resourceId)
+			response.Request.URL, _ = url.JoinPath(r.p.apiOpt.BaseURL.String(), resourceId)
 		}
 		p, err := client.NewPollableFromResp(*response, *opt)
 		if err != nil {

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -74,6 +74,7 @@ type pollData struct {
 	Status        types.Object `tfsdk:"status"`
 	UrlLocator    types.String `tfsdk:"url_locator"`
 	Header        types.Map    `tfsdk:"header"`
+	Query         types.Map    `tfsdk:"query"`
 	DefaultDelay  types.Int64  `tfsdk:"default_delay_sec"`
 }
 
@@ -216,6 +217,12 @@ func pollAttribute(s string) schema.Attribute {
 				Description:         "The header parameters. This overrides the `header` set in the resource block.",
 				MarkdownDescription: "The header parameters. This overrides the `header` set in the resource block.",
 				ElementType:         types.StringType,
+				Optional:            true,
+			},
+			"query": schema.MapAttribute{
+				Description:         "The query parameters. This overrides the `query` set in the resource block.",
+				MarkdownDescription: "The query parameters. This overrides the `query` set in the resource block.",
+				ElementType:         types.ListType{ElemType: types.StringType},
 				Optional:            true,
 			},
 			"default_delay_sec": schema.Int64Attribute{
@@ -527,7 +534,7 @@ func (r Resource) Create(ctx context.Context, req resource.CreateRequest, resp *
 			resp.Diagnostics.Append(diags...)
 			return
 		}
-		opt, diags := r.p.apiOpt.ForPoll(ctx, opt.Header, d)
+		opt, diags := r.p.apiOpt.ForPoll(ctx, opt.Header, opt.Query, d)
 		if diags.HasError() {
 			resp.Diagnostics.Append(diags...)
 			return
@@ -535,7 +542,7 @@ func (r Resource) Create(ctx context.Context, req resource.CreateRequest, resp *
 		if opt.UrlLocator == nil {
 			// Update the request URL to pointing to the resource path, which is mainly for resources whose create method is POST.
 			// As it will be used to poll the resource status.
-			response.Request.RawRequest.URL.Path = resourceId
+			response.Request.URL = resourceId
 		}
 		p, err := client.NewPollableFromResp(*response, *opt)
 		if err != nil {
@@ -753,7 +760,7 @@ func (r Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *
 				resp.Diagnostics.Append(diags...)
 				return
 			}
-			opt, diags := r.p.apiOpt.ForPoll(ctx, opt.Header, d)
+			opt, diags := r.p.apiOpt.ForPoll(ctx, opt.Header, opt.Query, d)
 			if diags.HasError() {
 				resp.Diagnostics.Append(diags...)
 				return
@@ -883,7 +890,7 @@ func (r Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *
 			resp.Diagnostics.Append(diags...)
 			return
 		}
-		opt, diags := r.p.apiOpt.ForPoll(ctx, opt.Header, d)
+		opt, diags := r.p.apiOpt.ForPoll(ctx, opt.Header, opt.Query, d)
 		if diags.HasError() {
 			resp.Diagnostics.Append(diags...)
 			return


### PR DESCRIPTION
Fix #41 

Previously, we were directly setting the `RawRequest.URL` as the encoded url. This causes the double encoding when we construct the pollable via calling the `url.String()`. Instead, we should set the encoded url to `URL`, and when constructing the pollable, we shall firstly `url.Parse()` the request URL. As a result, the `Path` will be in decoded form, and if the url is encoded before, the `RawPath` will be non-empty, which is a encode hint. Then, we intentionally clear the query part in the parsed URL, then call `url.String()` to get the encoded form and set it to the pollable's URL.

Since we are cleaning up the query string, we need to accordingly allow users to modify arbitrary query parameters so no to break their current use cases. Therefore, we introduce the `poll_xxx.query` attribute.