### PR TITLE
`restful_resource` data source: New attribute `allow_not_exist` to suppress error on 404 status code

### DIFF
--- a/docs/data-sources/resource.md
+++ b/docs/data-sources/resource.md
@@ -27,6 +27,7 @@ data "restful_resource" "test" {
 
 ### Optional
 
+- `allow_not_exist` (Boolean) Whether to throw error if the data source being queried doesn't exist (i.e. status code is 404). Defaults to `false`.
 - `header` (Map of String) The header parameters that are applied to each request. This overrides the `header` set in the provider block.
 - `output_attrs` (Set of String) A set of `output` attribute paths (in [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md)) that will be exported in the `output`. If this is not specified, all attributes will be exported by `output`.
 - `query` (Map of List of String) The query parameters that are applied to each request. This overrides the `query` set in the provider block.

--- a/internal/provider/data_source_jsonserver_test.go
+++ b/internal/provider/data_source_jsonserver_test.go
@@ -65,6 +65,24 @@ func TestDataSource_JSONServer_WithOutputAttrs(t *testing.T) {
 	})
 }
 
+func TestDataSource_JSONServer_NotExists(t *testing.T) {
+	dsaddr := "data.restful_resource.test"
+	d := newJsonServerData()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { d.precheck(t) },
+		ProtoV6ProviderFactories: acceptance.ProviderFactory(),
+		Steps: []resource.TestStep{
+			{
+				Config: d.dsNotExist(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dsaddr, "id"),
+					resource.TestCheckNoResourceAttr(dsaddr, "output"),
+				),
+			},
+		},
+	})
+}
+
 func (d jsonServerData) dsBasic() string {
 	return fmt.Sprintf(`
 provider "restful" {
@@ -130,6 +148,20 @@ resource "restful_resource" "test" {
 data "restful_resource" "test" {
   id = restful_resource.test.id
   output_attrs = ["foo", "obj.a"]
+}
+`, d.url)
+
+}
+
+func (d jsonServerData) dsNotExist() string {
+	return fmt.Sprintf(`
+provider "restful" {
+  base_url = %q
+}
+
+data "restful_resource" "test" {
+  id = "/notexist"
+  allow_not_exist = true
 }
 `, d.url)
 


### PR DESCRIPTION
New attribute `allow_not_exist` to suppress error on 404 status code for data source `restful_resource`.

Fix #45.