### PR TITLE
`restful_resource` data source: Supports `method` for `GET`, `HEAD` and (read-only) `POST`

### DIFF
--- a/docs/data-sources/resource.md
+++ b/docs/data-sources/resource.md
@@ -29,6 +29,7 @@ data "restful_resource" "test" {
 
 - `allow_not_exist` (Boolean) Whether to throw error if the data source being queried doesn't exist (i.e. status code is 404). Defaults to `false`.
 - `header` (Map of String) The header parameters that are applied to each request. This overrides the `header` set in the provider block.
+- `method` (String) The HTTP Method for the request. Allowed methods are a subset of methods defined in [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3) namely, `GET`, `HEAD`, and `POST`. `POST` support is only intended for read-only URLs, such as submitting a search. Defaults to `GET`.
 - `output_attrs` (Set of String) A set of `output` attribute paths (in [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md)) that will be exported in the `output`. If this is not specified, all attributes will be exported by `output`.
 - `precheck` (Attributes List) An array of prechecks that need to pass prior to the "Read" operation. Exactly one of `mutex` or `api` should be specified. (see [below for nested schema](#nestedatt--precheck))
 - `query` (Map of List of String) The query parameters that are applied to each request. This overrides the `query` set in the provider block.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -125,6 +125,8 @@ func (c *Client) Create(ctx context.Context, path string, body interface{}, opt 
 }
 
 type ReadOption struct {
+	// The http method used for reading, which defaults to "GET"
+	Method string
 	Query  Query
 	Header Header
 }
@@ -134,7 +136,16 @@ func (c *Client) Read(ctx context.Context, path string, opt ReadOption) (*resty.
 	req.SetQueryParamsFromValues(url.Values(opt.Query))
 	req.SetHeaders(opt.Header)
 
-	return req.Get(path)
+	switch opt.Method {
+	case "", "GET":
+		return req.Get(path)
+	case "HEAD":
+		return req.Head(path)
+	case "POST":
+		return req.Post(path)
+	default:
+		return nil, fmt.Errorf("unknown read method: %s", opt.Method)
+	}
 }
 
 type UpdateOption struct {

--- a/internal/provider/api_option.go
+++ b/internal/provider/api_option.go
@@ -97,6 +97,7 @@ func (opt apiOption) ForResourceDelete(ctx context.Context, d resourceData) (*cl
 
 func (opt apiOption) ForDataSourceRead(ctx context.Context, d dataSourceData) (*client.ReadOption, diag.Diagnostics) {
 	out := client.ReadOption{
+		Method: d.Method.ValueString(),
 		Query:  opt.Query.Clone().TakeOrSelf(ctx, d.Query),
 		Header: opt.Header.Clone().TakeOrSelf(ctx, d.Header),
 	}

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/tidwall/gjson"
 )
@@ -19,6 +21,7 @@ var _ datasource.DataSource = &DataSource{}
 
 type dataSourceData struct {
 	ID            types.String `tfsdk:"id"`
+	Method        types.String `tfsdk:"method"`
 	Query         types.Map    `tfsdk:"query"`
 	Header        types.Map    `tfsdk:"header"`
 	Selector      types.String `tfsdk:"selector"`
@@ -41,6 +44,14 @@ func (d *DataSource) Schema(ctx context.Context, req datasource.SchemaRequest, r
 				Description:         "The ID of the Resource, i.e. The path of the data source, relative to the `base_url` of the provider.",
 				MarkdownDescription: "The ID of the Resource, i.e. The path of the data source, relative to the `base_url` of the provider.",
 				Required:            true,
+			},
+			"method": schema.StringAttribute{
+				Description:         "The HTTP Method for the request. Allowed methods are a subset of methods defined in RFC7231 namely, GET, HEAD, and POST. POST support is only intended for read-only URLs, such as submitting a search. Defaults to `GET`.",
+				MarkdownDescription: "The HTTP Method for the request. Allowed methods are a subset of methods defined in [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3) namely, `GET`, `HEAD`, and `POST`. `POST` support is only intended for read-only URLs, such as submitting a search. Defaults to `GET`.",
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("GET", "POST", "HEAD"),
+				},
 			},
 			"query": schema.MapAttribute{
 				Description:         "The query parameters that are applied to each request. This overrides the `query` set in the provider block.",


### PR DESCRIPTION
This PR extends the `restful_resource` DS to support method to be `HEAD` and `POST` other than `GET`, which aligns with https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http#method.

Related to #66.