### PR TITLE
`restful_resource` resource & data source: Extend the `output_attrs` to support arrays

### DIFF
--- a/internal/attrpath/attrpath.go
+++ b/internal/attrpath/attrpath.go
@@ -1,0 +1,105 @@
+package attrpath
+
+import (
+	"fmt"
+	"strings"
+	"text/scanner"
+)
+
+type AttrPath []AttrStep
+
+func (p AttrPath) String() string {
+	var ol []string
+	for _, step := range p {
+		switch step := step.(type) {
+		case AttrStepValue:
+			var val string
+			for _, c := range step {
+				switch c {
+				case '.', '#', '\\':
+					val += `\` + string(c)
+				default:
+					val += string(c)
+				}
+			}
+			ol = append(ol, val)
+		case AttrStepSplat:
+			ol = append(ol, "#")
+		}
+	}
+	return strings.Join(ol, ".")
+}
+
+type AttrStep interface {
+	isAttrStep()
+}
+
+type AttrStepValue string
+
+func (AttrStepValue) isAttrStep() {}
+
+type AttrStepSplat struct{}
+
+func (AttrStepSplat) isAttrStep() {}
+
+func ParseAttrPath(input string) (AttrPath, error) {
+	var gerr error
+	s := scanner.Scanner{
+		Error: func(s *scanner.Scanner, msg string) {
+			gerr = fmt.Errorf("%s: %s", s.Pos().String(), msg)
+		},
+	}
+	s.Init(strings.NewReader(input))
+	var escape bool
+	var path AttrPath
+	var value AttrStepValue
+	for tok := s.Scan(); tok != scanner.EOF; tok = s.Scan() {
+		if gerr != nil {
+			return nil, gerr
+		}
+
+		tk := s.TokenText()
+
+		if escape {
+			escape = false
+			value += AttrStepValue(tk)
+			continue
+		}
+
+		switch tk {
+		case "\\":
+			escape = true
+			continue
+		case ".":
+			if s.Peek() == '.' {
+				return nil, fmt.Errorf("%s: consecutive '.' is not allowed", s.Pos().String())
+			}
+			path = append(path, value)
+			value = ""
+			continue
+		case "#":
+			// If there is prepending value for this step, just append the "#", as part of the value
+			if value != "" {
+				value += "#"
+				continue
+			}
+
+			if peek := s.Peek(); peek == '.' || peek == scanner.EOF {
+				path = append(path, AttrStepSplat{})
+				s.Scan()
+				continue
+			}
+
+			// If the next tok is not a '.', then regard "#" as a regular value
+			value += "#"
+			continue
+		default:
+			value += AttrStepValue(tk)
+			continue
+		}
+	}
+	if value != "" {
+		path = append(path, value)
+	}
+	return path, nil
+}

--- a/internal/attrpath/attrpath.go
+++ b/internal/attrpath/attrpath.go
@@ -42,7 +42,7 @@ type AttrStepSplat struct{}
 
 func (AttrStepSplat) isAttrStep() {}
 
-func ParseAttrPath(input string) (AttrPath, error) {
+func Path(input string) (AttrPath, error) {
 	var gerr error
 	s := scanner.Scanner{
 		Error: func(s *scanner.Scanner, msg string) {

--- a/internal/attrpath/attrpath_test.go
+++ b/internal/attrpath/attrpath_test.go
@@ -1,0 +1,191 @@
+package attrpath
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAttrPath(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		isErr  bool
+		expect AttrPath
+	}{
+		{
+			name:   "empty",
+			input:  "",
+			expect: nil,
+		},
+		{
+			name:  "one value (single char)",
+			input: "a",
+			expect: AttrPath{
+				AttrStepValue("a"),
+			},
+		},
+		{
+			name:  "one value",
+			input: "aa",
+			expect: AttrPath{
+				AttrStepValue("aa"),
+			},
+		},
+		{
+			name:  "one value (ends with #)",
+			input: "a#",
+			expect: AttrPath{
+				AttrStepValue("a#"),
+			},
+		},
+		{
+			name:  "one value (starts with #)",
+			input: "#a",
+			expect: AttrPath{
+				AttrStepValue("#a"),
+			},
+		},
+		{
+			name:  "one value (surrounded with #)",
+			input: "#a#",
+			expect: AttrPath{
+				AttrStepValue("#a#"),
+			},
+		},
+		{
+			name:  "one splat",
+			input: "#",
+			expect: AttrPath{
+				AttrStepSplat{},
+			},
+		},
+		{
+			name:  "consecutive splats",
+			input: "##",
+			expect: AttrPath{
+				AttrStepValue("##"),
+			},
+		},
+		{
+			name:  "escaped dot",
+			input: `\.`,
+			expect: AttrPath{
+				AttrStepValue("."),
+			},
+		},
+		{
+			name:  "escaped #",
+			input: `\#`,
+			expect: AttrPath{
+				AttrStepValue("#"),
+			},
+		},
+		{
+			name:  "escaped \\",
+			input: `\\`,
+			expect: AttrPath{
+				AttrStepValue(`\`),
+			},
+		},
+		{
+			name:  "mixed",
+			input: `a.#.a\.\#\\b.##`,
+			expect: AttrPath{
+				AttrStepValue(`a`),
+				AttrStepSplat{},
+				AttrStepValue(`a.#\b`),
+				AttrStepValue(`##`),
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := ParseAttrPath(tt.input)
+			if tt.isErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestAttrPathString(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "empty",
+			input:  "",
+			expect: "",
+		},
+		{
+			name:   "one value (single char)",
+			input:  "a",
+			expect: "a",
+		},
+		{
+			name:   "one value",
+			input:  "aa",
+			expect: "aa",
+		},
+		{
+			name:   "one value (ends with #)",
+			input:  "a#",
+			expect: `a\#`,
+		},
+		{
+			name:   "one value (starts with #)",
+			input:  "#a",
+			expect: `\#a`,
+		},
+		{
+			name:   "one value (surrounded with #)",
+			input:  "#a#",
+			expect: `\#a\#`,
+		},
+		{
+			name:   "one splat",
+			input:  "#",
+			expect: "#",
+		},
+		{
+			name:   "consecutive splats",
+			input:  "##",
+			expect: `\#\#`,
+		},
+		{
+			name:   "escaped dot",
+			input:  `\.`,
+			expect: `\.`,
+		},
+		{
+			name:   "escaped #",
+			input:  `\#`,
+			expect: `\#`,
+		},
+		{
+			name:   "escaped \\",
+			input:  `\\`,
+			expect: `\\`,
+		},
+		{
+			name:   "mixed",
+			input:  `a.#.a\.\#\\b.##`,
+			expect: `a.#.a\.\#\\b.\#\#`,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := ParseAttrPath(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, actual.String())
+		})
+	}
+}

--- a/internal/attrpath/attrpath_test.go
+++ b/internal/attrpath/attrpath_test.go
@@ -102,7 +102,7 @@ func TestParseAttrPath(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, err := ParseAttrPath(tt.input)
+			actual, err := Path(tt.input)
 			if tt.isErr {
 				require.Error(t, err)
 				return
@@ -183,7 +183,7 @@ func TestAttrPathString(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, err := ParseAttrPath(tt.input)
+			actual, err := Path(tt.input)
 			require.NoError(t, err)
 			require.Equal(t, tt.expect, actual.String())
 		})

--- a/internal/provider/body.go
+++ b/internal/provider/body.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/magodo/terraform-provider-restful/internal/attrpath"
 	"github.com/tidwall/gjson"
@@ -137,17 +138,80 @@ func getUpdatedJSONForImport(oldJSON, newJSON interface{}) (interface{}, error) 
 	return newJSON, nil
 }
 
+type ObjectOrArray interface {
+}
+
 // Given a JSON object, only keep the attributes specified and remove the others.
-func FilterAttrsInJSON(doc string, attrs []attrpath.AttrPath) (string, error) {
-	var objOrArray any
-	if err := json.Unmarshal([]byte(doc), &objOrArray); err != nil {
+func FilterAttrsInJSON(doc string, attrs []string) (string, error) {
+	if len(attrs) == 0 {
+		return doc, nil
+	}
+
+	var paths []attrpath.AttrPath
+	for _, attr := range attrs {
+		path, err := attrpath.Path(attr)
+		if err != nil {
+			return "", fmt.Errorf("parsing %q: %v", attr, err)
+		}
+		paths = append(paths, path)
+	}
+
+	var jsonDoc any
+	if err := json.Unmarshal([]byte(doc), &jsonDoc); err != nil {
 		return "", err
 	}
+
+	var odoc any
+	for _, path := range paths {
+		doc, err := filterAttrInJSON(jsonDoc, attrpath.AttrPath{}, path)
+		if err != nil {
+			return "", err
+		}
+		if odoc == nil {
+			odoc = doc
+			continue
+		}
+		switch d := odoc.(type) {
+		case map[string]interface{}:
+			dd, ok := doc.(map[string]interface{})
+			if !ok {
+				return "", fmt.Errorf("expect value %v to be a map, but got %T", doc, doc)
+			}
+			odoc, err = mergeObject("", d, dd)
+			if err != nil {
+				return "", err
+			}
+		case []interface{}:
+			dd, ok := doc.([]interface{})
+			if !ok {
+				return "", fmt.Errorf("expect value %v to be an array, but got %T", doc, doc)
+			}
+			odoc, err = mergeArray("", d, dd)
+			if err != nil {
+				return "", err
+			}
+		default:
+			return "", fmt.Errorf("unsupported types for JSON attr filtering: %T", odoc)
+		}
+	}
+	b, err := json.Marshal(odoc)
+	if err != nil {
+		return "", fmt.Errorf("marshalling the filtered document: %v", err)
+	}
+	return string(b), nil
 }
 
 func filterAttrInJSON(doc any, prefix, path attrpath.AttrPath) (any, error) {
 	if len(path) == 0 {
-		return doc, nil
+		var odoc interface{}
+		b, err := json.Marshal(doc)
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(b, &odoc); err != nil {
+			return nil, err
+		}
+		return odoc, nil
 	}
 
 	step := path[0]
@@ -158,31 +222,35 @@ func filterAttrInJSON(doc any, prefix, path attrpath.AttrPath) (any, error) {
 		switch step := step.(type) {
 		case attrpath.AttrStepValue:
 			// This must be an splat
-			// TODO: shall we support index?
 			return nil, fmt.Errorf("%s: expect a splat step, got a value step (%s)", prefix, step)
 		case attrpath.AttrStepSplat:
+			odoc := []interface{}{}
 			for i := range doc {
 				indoc, err := filterAttrInJSON(doc[i], prefix, remain)
 				if err != nil {
 					return nil, err
 				}
-				doc[i] = indoc
+				odoc = append(odoc, indoc)
 			}
-			return doc, nil
+			return odoc, nil
 		default:
 			return nil, fmt.Errorf("%s: unknown step type %T", prefix, step)
 		}
 	case map[string]interface{}:
 		switch step := step.(type) {
 		case attrpath.AttrStepValue:
+			odoc := map[string]interface{}{}
 			k := string(step)
-			v := doc[k]
+			v, ok := doc[k]
+			if !ok {
+				return odoc, nil
+			}
 			indoc, err := filterAttrInJSON(v, prefix, remain)
 			if err != nil {
 				return nil, err
 			}
-			doc[k] = indoc
-			return doc, nil
+			odoc[k] = indoc
+			return odoc, nil
 		case attrpath.AttrStepSplat:
 			return nil, fmt.Errorf("%s: expect a value step, got a splat step", prefix)
 		default:
@@ -191,4 +259,91 @@ func filterAttrInJSON(doc any, prefix, path attrpath.AttrPath) (any, error) {
 	default:
 		return nil, fmt.Errorf("invalid document type %T", doc)
 	}
+}
+
+func mergeArray(addr string, arr1, arr2 []interface{}) ([]interface{}, error) {
+	if len(arr1) != len(arr2) {
+		return nil, fmt.Errorf("%s: length not the same %d != %d", addr, len(arr1), len(arr2))
+	}
+	arr := []interface{}{}
+	for i := range arr1 {
+		nextaddr := addr + "." + strconv.Itoa(i)
+		e1, e2 := arr1[i], arr2[i]
+		switch e1 := e1.(type) {
+		case map[string]interface{}:
+			e2, ok := e2.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("%s: expect value %v to be a map, but got %T", nextaddr, e2, e2)
+			}
+			e, err := mergeObject(nextaddr, e1, e2)
+			if err != nil {
+				return nil, fmt.Errorf("merging %s: %v", nextaddr, err)
+			}
+			arr = append(arr, e)
+		case []interface{}:
+			e2, ok := e2.([]interface{})
+			if !ok {
+				return nil, fmt.Errorf("%s: expect value %v to be an array, but got %T", nextaddr, e2, e2)
+			}
+			e, err := mergeArray(nextaddr, e1, e2)
+			if err != nil {
+				return nil, fmt.Errorf("merging %s: %v", nextaddr, err)
+			}
+			arr = append(arr, e)
+		default:
+			if e1 != e2 {
+				return nil, fmt.Errorf("%s: two values are not the same: %v != %v", nextaddr, e1, e2)
+			}
+			arr = append(arr, e1)
+		}
+	}
+	return arr, nil
+}
+
+func mergeObject(addr string, obj1, obj2 map[string]interface{}) (map[string]interface{}, error) {
+	obj := map[string]interface{}{}
+	intersecKey := map[string]bool{}
+	for k1, v1 := range obj1 {
+		if _, ok := obj2[k1]; !ok {
+			obj[k1] = v1
+			continue
+		}
+		intersecKey[k1] = true
+	}
+	for k2, v2 := range obj2 {
+		if _, ok := obj1[k2]; !ok {
+			obj[k2] = v2
+		}
+	}
+	var err error
+	for k := range intersecKey {
+		v1, v2 := obj1[k], obj2[k]
+		nextaddr := addr + "." + k
+		switch v1 := v1.(type) {
+		case map[string]interface{}:
+			v2, ok := v2.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("%s: expect value %v to be a map, but got %T", nextaddr, v2, v2)
+			}
+			obj[k], err = mergeObject(nextaddr, v1, v2)
+			if err != nil {
+				return nil, fmt.Errorf("merging %s: %v", nextaddr, err)
+			}
+		case []interface{}:
+			v2, ok := v2.([]interface{})
+			if !ok {
+				return nil, fmt.Errorf("%s: expect value %v to be an array, but got %T", nextaddr, v2, v2)
+			}
+			obj[k], err = mergeArray(nextaddr, v1, v2)
+			if err != nil {
+				return nil, fmt.Errorf("merging %s: %v", nextaddr, err)
+			}
+		default:
+			if v1 != v2 {
+				return nil, fmt.Errorf("%s: two values are not the same: %v != %v", nextaddr, v1, v2)
+			}
+			obj[k] = v1
+		}
+	}
+	return obj, nil
 }


### PR DESCRIPTION
Fix #68

## Test

```shell
/tmp/restful via 💠 default
💤  cat main.tf
terraform {
  required_providers {
    restful = {
      source = "magodo/restful"
    }
  }
}

provider "restful" {
  base_url = "http://localhost:3000"
}

resource "restful_resource" "test" {
  path = "/posts"
  body = jsonencode({
    author = "magodo"
    title  = "foobar"
  })
  read_path = "$(path)/$(body.id)"
}

data "restful_resource" "all" {
  id         = "/posts"
  depends_on = [restful_resource.test]
}

data "restful_resource" "filter" {
  id = "/posts"
  output_attrs = [
    "#.id",
    "#.title",
  ]

  depends_on = [restful_resource.test]
}

/tmp/restful via 💠 default
💤  tf show
# data.restful_resource.all:
data "restful_resource" "all" {
    id     = "/posts"
    output = jsonencode(
        [
            {
                author = "typicode"
                id     = 1
                title  = "json-server"
            },
            {
                author = "magodo"
                id     = 2
                title  = "foobar"
            },
        ]
    )
}

# data.restful_resource.filter:
data "restful_resource" "filter" {
    id           = "/posts"
    output       = jsonencode(
        [
            {
                id    = 1
                title = "json-server"
            },
            {
                id    = 2
                title = "foobar"
            },
        ]
    )
    output_attrs = [
        "#.id",
        "#.title",
    ]
}

# restful_resource.test:
resource "restful_resource" "test" {
    body      = jsonencode(
        {
            author = "magodo"
            title  = "foobar"
        }
    )
    id        = "/posts/2"
    output    = jsonencode(
        {
            author = "magodo"
            id     = 2
            title  = "foobar"
        }
    )
    path      = "/posts"
    read_path = "$(path)/$(body.id)"
}
```