### PR TITLE
`restful_resource` - Update `import_spec` to remove some unnecessary properties, and allow `body` to be optional

### DIFF
--- a/docs/data-sources/resource.md
+++ b/docs/data-sources/resource.md
@@ -72,3 +72,5 @@ Required:
 Optional:
 
 - `pending` (List of String) The expected status sentinels for pending status.
+
+

--- a/docs/resources/operation.md
+++ b/docs/resources/operation.md
@@ -112,3 +112,5 @@ Required:
 Optional:
 
 - `pending` (List of String) The expected status sentinels for pending status.
+
+

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -272,22 +272,17 @@ Import is supported using the following syntax:
 # The import spec consists of following keys:
 #
 # - id (Required)               : The resource id.
-# - path (Required)             : The path used to create the resource.
-# - update_path (Optional)      : The path used to update the resource.
-# - delete_path (Optional)      : The path used to delete the resource.
+# - path (Required)             : The path used to create the resource (as this is force new)
 # - query (Optional)            : The query parameters.
 # - header (Optional)           : The header.
-# - create_method (Optional)    : The method used to create the resource. Defaults to POST.
-# - update_method (Optional)    : The method used to update the resource. Defaults to PUT
-# - delete_method (Optional)    : The method used to delete the resource. Defaults to DELETE.
-# - body (Optional)             : The interested properties in the response body that you want to manage via this resource. If you omit this, then all the properties will be keeping track, which in 
-#                                 most cases is not what you want (e.g. the read only attributes shouldn't be managed).
+# - body (Optional)             : The interested properties in the response body that you want to manage via this resource.
+#                                 If you omit this, then all the properties will be keeping track, which in most cases is 
+#                                 not what you want (e.g. the read only attributes shouldn't be managed).
 #                                 The value of each property is not important here, hence leave them as `null`.
 terraform import restful_resource.example '{
   "id": "/subscriptions/0-0-0-0/resourceGroups/example",
   "path": "/subscriptions/0-0-0-0/resourceGroups/example",
   "query": {"api-version": ["2020-06-01"]},
-  "create_method": "PUT",
   "body": {
     "location": null,
     "tags": null

--- a/examples/resources/restful_resource/import.sh
+++ b/examples/resources/restful_resource/import.sh
@@ -1,22 +1,17 @@
 # The import spec consists of following keys:
 #
 # - id (Required)               : The resource id.
-# - path (Required)             : The path used to create the resource.
-# - update_path (Optional)      : The path used to update the resource.
-# - delete_path (Optional)      : The path used to delete the resource.
+# - path (Required)             : The path used to create the resource (as this is force new)
 # - query (Optional)            : The query parameters.
 # - header (Optional)           : The header.
-# - create_method (Optional)    : The method used to create the resource. Defaults to POST.
-# - update_method (Optional)    : The method used to update the resource. Defaults to PUT
-# - delete_method (Optional)    : The method used to delete the resource. Defaults to DELETE.
-# - body (Optional)             : The interested properties in the response body that you want to manage via this resource. If you omit this, then all the properties will be keeping track, which in 
-#                                 most cases is not what you want (e.g. the read only attributes shouldn't be managed).
+# - body (Optional)             : The interested properties in the response body that you want to manage via this resource.
+#                                 If you omit this, then all the properties will be keeping track, which in most cases is 
+#                                 not what you want (e.g. the read only attributes shouldn't be managed).
 #                                 The value of each property is not important here, hence leave them as `null`.
 terraform import restful_resource.example '{
   "id": "/subscriptions/0-0-0-0/resourceGroups/example",
   "path": "/subscriptions/0-0-0-0/resourceGroups/example",
   "query": {"api-version": ["2020-06-01"]},
-  "create_method": "PUT",
   "body": {
     "location": null,
     "tags": null

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -1013,13 +1013,8 @@ type importSpec struct {
 func (Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idPath := tfpath.Root("id")
 	path := tfpath.Root("path")
-	updatePath := tfpath.Root("update_path")
-	deletePath := tfpath.Root("delete_path")
 	queryPath := tfpath.Root("query")
 	headerPath := tfpath.Root("header")
-	createMethodPath := tfpath.Root("create_method")
-	updateMethodPath := tfpath.Root("update_method")
-	deleteMethodPath := tfpath.Root("delete_method")
 	bodyPath := tfpath.Root("body")
 
 	var imp importSpec
@@ -1031,6 +1026,23 @@ func (Resource) ImportState(ctx context.Context, req resource.ImportStateRequest
 		return
 	}
 
+	if imp.Id == "" {
+		resp.Diagnostics.AddError(
+			"Resource Import Error",
+			fmt.Sprintf("`id` not specified in the import spec"),
+		)
+		return
+	}
+
+	if imp.Path == "" {
+		resp.Diagnostics.AddError(
+			"Resource Import Error",
+			fmt.Sprintf("`path` not specified in the import spec"),
+		)
+		return
+	}
+
+	var body string
 	if len(imp.Body) != 0 {
 		b, err := json.Marshal(imp.Body)
 		if err != nil {
@@ -1040,17 +1052,12 @@ func (Resource) ImportState(ctx context.Context, req resource.ImportStateRequest
 			)
 			return
 		}
-		body := __IMPORT_HEADER__ + string(b)
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, bodyPath, body)...)
+		body = string(b)
 	}
-
+	body = __IMPORT_HEADER__ + body
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, idPath, imp.Id)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path, imp.Path)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, updatePath, imp.UpdatePath)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, deletePath, imp.DeletePath)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, bodyPath, body)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, queryPath, imp.Query)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, headerPath, imp.Header)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, createMethodPath, imp.CreateMethod)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, updateMethodPath, imp.UpdateMethod)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, deleteMethodPath, imp.DeleteMethod)...)
 }


### PR DESCRIPTION
Previously, the `body` is required to specify in the import spec (though the document said it is optional). This PR makes it truely optional.

Meanwhile, we removed several unnecessary properties from the import spec, in order to make the import spec as simple as possible, where only `id` and `path` are required now.