### PR TITLE
`restful_resource` & `restful_operation` - Remove `query` for `poll_xxx` block

### DIFF
--- a/docs/resources/operation.md
+++ b/docs/resources/operation.md
@@ -63,7 +63,6 @@ Optional:
 
 - `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
 - `header` (Map of String) The header parameters. This overrides the `header` set in the resource block.
-- `query` (Map of List of String) The query parameters. This overrides the `query` set in the resource block.
 - `url_locator` (String) Specifies how to discover the polling url. The format can be one of `header.path` (use the property at `path` in response header), `body.path` (use the property at `path` in response body) or `exact.value` (use the exact `value`). When absent, the resource's path is used for polling.
 
 <a id="nestedatt--poll--status"></a>

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -84,7 +84,6 @@ Optional:
 
 - `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
 - `header` (Map of String) The header parameters. This overrides the `header` set in the resource block.
-- `query` (Map of List of String) The query parameters. This overrides the `query` set in the resource block.
 - `url_locator` (String) Specifies how to discover the polling url. The format can be one of `header.path` (use the property at `path` in response header), `body.path` (use the property at `path` in response body) or `exact.value` (use the exact `value`). When absent, the resource's path is used for polling.
 
 <a id="nestedatt--poll_create--status"></a>
@@ -112,7 +111,6 @@ Optional:
 
 - `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
 - `header` (Map of String) The header parameters. This overrides the `header` set in the resource block.
-- `query` (Map of List of String) The query parameters. This overrides the `query` set in the resource block.
 - `url_locator` (String) Specifies how to discover the polling url. The format can be one of `header.path` (use the property at `path` in response header), `body.path` (use the property at `path` in response body) or `exact.value` (use the exact `value`). When absent, the resource's path is used for polling.
 
 <a id="nestedatt--poll_delete--status"></a>
@@ -140,7 +138,6 @@ Optional:
 
 - `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
 - `header` (Map of String) The header parameters. This overrides the `header` set in the resource block.
-- `query` (Map of List of String) The query parameters. This overrides the `query` set in the resource block.
 - `url_locator` (String) Specifies how to discover the polling url. The format can be one of `header.path` (use the property at `path` in response header), `body.path` (use the property at `path` in response body) or `exact.value` (use the exact `value`). When absent, the resource's path is used for polling.
 
 <a id="nestedatt--poll_update--status"></a>

--- a/internal/provider/api_option.go
+++ b/internal/provider/api_option.go
@@ -143,20 +143,18 @@ func (opt apiOption) ForPoll(ctx context.Context, defaultHeader client.Header, d
 		header = header.Clone().TakeOrSelf(ctx, d.Header)
 	}
 
-	query := defaultQuery
-	if !d.Query.IsNull() {
-		query = query.Clone().TakeOrSelf(ctx, d.Query)
-	}
-
 	return &client.PollOption{
 		StatusLocator: statusLocator,
 		Status: client.PollingStatus{
 			Success: status.Success,
 			Pending: status.Pending,
 		},
-		UrlLocator:   urlLocator,
-		Header:       header,
-		Query:        query,
+		UrlLocator: urlLocator,
+		Header:     header,
+
+		// The poll option always use the default query, which is typically is from the original request
+		Query: defaultQuery,
+
 		DefaultDelay: time.Duration(d.DefaultDelay.ValueInt64()) * time.Second,
 	}, nil
 }

--- a/internal/provider/operation_resource.go
+++ b/internal/provider/operation_resource.go
@@ -184,7 +184,7 @@ func (r *OperationResource) createOrUpdate(ctx context.Context, tfplan tfsdk.Pla
 			// As it will be used to poll the resource status.
 			response.Request.URL, _ = url.JoinPath(r.p.apiOpt.BaseURL.String(), resourceId)
 		}
-		p, err := client.NewPollableFromResp(*response, *opt)
+		p, err := client.NewPollableForPoll(*response, *opt)
 		if err != nil {
 			diagnostics.AddError(
 				"Operation: Failed to build poller from the response of the initiated request",

--- a/internal/provider/precheck.go
+++ b/internal/provider/precheck.go
@@ -29,7 +29,7 @@ func precheck(ctx context.Context, c *client.Client, apiOpt apiOption, defaultPa
 				if diags.HasError() {
 					return nil, diags
 				}
-				p, err := client.NewPollable(*opt)
+				p, err := client.NewPollableForPrecheck(*opt)
 				if err != nil {
 					return nil, diag.Diagnostics{
 						diag.NewErrorDiagnostic(

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -79,7 +79,6 @@ type pollData struct {
 	Status        types.Object `tfsdk:"status"`
 	UrlLocator    types.String `tfsdk:"url_locator"`
 	Header        types.Map    `tfsdk:"header"`
-	Query         types.Map    `tfsdk:"query"`
 	DefaultDelay  types.Int64  `tfsdk:"default_delay_sec"`
 }
 
@@ -249,12 +248,6 @@ func pollAttribute(s string) schema.Attribute {
 				Description:         "The header parameters. This overrides the `header` set in the resource block.",
 				MarkdownDescription: "The header parameters. This overrides the `header` set in the resource block.",
 				ElementType:         types.StringType,
-				Optional:            true,
-			},
-			"query": schema.MapAttribute{
-				Description:         "The query parameters. This overrides the `query` set in the resource block.",
-				MarkdownDescription: "The query parameters. This overrides the `query` set in the resource block.",
-				ElementType:         types.ListType{ElemType: types.StringType},
 				Optional:            true,
 			},
 			"default_delay_sec": schema.Int64Attribute{
@@ -636,7 +629,7 @@ func (r Resource) Create(ctx context.Context, req resource.CreateRequest, resp *
 			// As it will be used to poll the resource status.
 			response.Request.URL = resourceId
 		}
-		p, err := client.NewPollableFromResp(*response, *opt)
+		p, err := client.NewPollableForPoll(*response, *opt)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Create: Failed to build poller from the response of the initiated request",
@@ -853,7 +846,7 @@ func (r Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *
 				resp.Diagnostics.Append(diags...)
 				return
 			}
-			p, err := client.NewPollableFromResp(*response, *opt)
+			p, err := client.NewPollableForPoll(*response, *opt)
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"Update: Failed to build poller from the response of the initiated request",
@@ -962,7 +955,7 @@ func (r Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *
 			resp.Diagnostics.Append(diags...)
 			return
 		}
-		p, err := client.NewPollableFromResp(*response, *opt)
+		p, err := client.NewPollableForPoll(*response, *opt)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Delete: Failed to build poller from the response of the initiated request",


### PR DESCRIPTION
This PR removes the `query` from `poll_xxx` block for `restful_resource` and `restful_operation`.

During polling, the actual query used is either from the polling `url_locator` (as the polling URL is expected to contain the complete URL, including the query needed), or inherit from the originating request if `url_locator` not specified.

Previously, we were intentionally removing the query part from the polling URL, and inherit from the originating request, which can be overwritten by the `poll_xxx.query`. This causes issues like #60.

Fix #69.