### PR TITLE
`restful_resouce` (res&ds) & `restful_operation`: Support `retry(_(create|read|update|delete))`

### DIFF
--- a/docs/data-sources/resource.md
+++ b/docs/data-sources/resource.md
@@ -33,6 +33,7 @@ data "restful_resource" "test" {
 - `output_attrs` (Set of String) A set of `output` attribute paths (in [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md)) that will be exported in the `output`. If this is not specified, all attributes will be exported by `output`.
 - `precheck` (Attributes List) An array of prechecks that need to pass prior to the "Read" operation. Exactly one of `mutex` or `api` should be specified. (see [below for nested schema](#nestedatt--precheck))
 - `query` (Map of List of String) The query parameters that are applied to each request. This overrides the `query` set in the provider block.
+- `retry` (Attributes) The retry option for the "Read" operation (see [below for nested schema](#nestedatt--retry))
 - `selector` (String) A selector in [gjson query syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md#queries), that is used when `id` represents a collection of resources, to select exactly one member resource of from it
 
 ### Read-Only
@@ -58,7 +59,7 @@ Required:
 
 Optional:
 
-- `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
+- `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second. Defaults to `10`.
 - `header` (Map of String) The header parameters. This overrides the `header` set in the resource block.
 - `query` (Map of List of String) The query parameters. This overrides the `query` set in the resource block.
 
@@ -74,3 +75,29 @@ Optional:
 - `pending` (List of String) The expected status sentinels for pending status.
 
 
+
+
+<a id="nestedatt--retry"></a>
+### Nested Schema for `retry`
+
+Required:
+
+- `status` (Attributes) The expected status sentinels. (see [below for nested schema](#nestedatt--retry--status))
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the gjson syntax. In most case, you shall use `code`, as you most not expect a write-like operation to perform multiple times.
+
+Optional:
+
+- `count` (Number) The maximum allowed retries. Defaults to `3`.
+- `max_wait_in_sec` (Number) The maximum allowed retry wait time. Defaults to `3600`.
+- `wait_in_sec` (Number) The initial retry wait time between two retries in second, if there is no `Retry-After` in the response header, or the `Retry-After` is less than this. The wait time will be increased in capped exponential backoff with jitter, at most up to `max_wait_in_sec` (if not null). Defaults to `1`.
+
+<a id="nestedatt--retry--status"></a>
+### Nested Schema for `retry.status`
+
+Required:
+
+- `success` (String) The expected status sentinel for suceess status.
+
+Optional:
+
+- `pending` (List of String) The expected status sentinels for pending status.

--- a/docs/resources/operation.md
+++ b/docs/resources/operation.md
@@ -45,6 +45,7 @@ resource "restful_operation" "register_rp" {
 - `poll` (Attributes) The polling option for the "API" operation (see [below for nested schema](#nestedatt--poll))
 - `precheck` (Attributes List) An array of prechecks that need to pass prior to the "API" operation. Exactly one of `mutex` or `api` should be specified. (see [below for nested schema](#nestedatt--precheck))
 - `query` (Map of List of String) The query parameters that are applied to each request. This overrides the `query` set in the provider block.
+- `retry` (Attributes) The retry option for the "API" operation (see [below for nested schema](#nestedatt--retry))
 
 ### Read-Only
 
@@ -61,7 +62,7 @@ Required:
 
 Optional:
 
-- `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
+- `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second. Defaults to `10`.
 - `header` (Map of String) The header parameters. This overrides the `header` set in the resource block.
 - `url_locator` (String) Specifies how to discover the polling url. The format can be one of `header.path` (use the property at `path` in response header), `body.path` (use the property at `path` in response body) or `exact.value` (use the exact `value`). When absent, the resource's path is used for polling.
 
@@ -96,7 +97,7 @@ Required:
 
 Optional:
 
-- `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
+- `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second. Defaults to `10`.
 - `header` (Map of String) The header parameters. This overrides the `header` set in the resource block.
 - `path` (String) The path used to query readiness, relative to the `base_url` of the provider. By default, the `path` of this resource is used.
 - `query` (Map of List of String) The query parameters. This overrides the `query` set in the resource block.
@@ -113,3 +114,29 @@ Optional:
 - `pending` (List of String) The expected status sentinels for pending status.
 
 
+
+
+<a id="nestedatt--retry"></a>
+### Nested Schema for `retry`
+
+Required:
+
+- `status` (Attributes) The expected status sentinels. (see [below for nested schema](#nestedatt--retry--status))
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the gjson syntax. In most case, you shall use `code`, as you most not expect a write-like operation to perform multiple times.
+
+Optional:
+
+- `count` (Number) The maximum allowed retries. Defaults to `3`.
+- `max_wait_in_sec` (Number) The maximum allowed retry wait time. Defaults to `3600`.
+- `wait_in_sec` (Number) The initial retry wait time between two retries in second, if there is no `Retry-After` in the response header, or the `Retry-After` is less than this. The wait time will be increased in capped exponential backoff with jitter, at most up to `max_wait_in_sec` (if not null). Defaults to `1`.
+
+<a id="nestedatt--retry--status"></a>
+### Nested Schema for `retry.status`
+
+Required:
+
+- `success` (String) The expected status sentinel for suceess status.
+
+Optional:
+
+- `pending` (List of String) The expected status sentinels for pending status.

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -63,6 +63,9 @@ resource "restful_resource" "rg" {
 - `query` (Map of List of String) The query parameters that are applied to each request. This overrides the `query` set in the provider block.
 - `read_path` (String) The API path used to read the resource, which is used as the `id`. The `path` is used as the `id` instead if `read_path` is absent. The path can be string literal, or combined by followings: `$(path)` expanded to `path`, `$(body.x.y.z)` expands to the `x.y.z` property (urlencoded) in API body, `#(body.id)` expands to the `id` property, with `base_url` prefix trimmed.
 - `read_selector` (String) A selector in [gjson query syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md#queries) query syntax, that is used when read returns a collection of resources, to select exactly one member resource of from it. By default, the whole response body is used as the body.
+- `retry_create` (Attributes) The retry option for the "Create (i.e. PUT/POST)" operation (see [below for nested schema](#nestedatt--retry_create))
+- `retry_delete` (Attributes) The retry option for the "Delete (i.e. DELETE)" operation (see [below for nested schema](#nestedatt--retry_delete))
+- `retry_update` (Attributes) The retry option for the "Update (i.e. PUT/PATCH/POST)" operation (see [below for nested schema](#nestedatt--retry_update))
 - `update_method` (String) The method used to update the resource. Possible values are `PUT`, `POST`, and `PATCH`. This overrides the `update_method` set in the provider block (defaults to PUT).
 - `update_path` (String) The API path used to update the resource. The `id` is used instead if `update_path` is absent. The path can be string literal, or combined by followings: `$(path)` expanded to `path`, `$(body.x.y.z)` expands to the `x.y.z` property (urlencoded) in API body, `#(body.id)` expands to the `id` property, with `base_url` prefix trimmed.
 - `write_only_attrs` (List of String) A list of paths (in [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md)) to the attributes that are only settable, but won't be read in GET response.
@@ -82,7 +85,7 @@ Required:
 
 Optional:
 
-- `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
+- `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second. Defaults to `10`.
 - `header` (Map of String) The header parameters. This overrides the `header` set in the resource block.
 - `url_locator` (String) Specifies how to discover the polling url. The format can be one of `header.path` (use the property at `path` in response header), `body.path` (use the property at `path` in response body) or `exact.value` (use the exact `value`). When absent, the resource's path is used for polling.
 
@@ -109,7 +112,7 @@ Required:
 
 Optional:
 
-- `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
+- `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second. Defaults to `10`.
 - `header` (Map of String) The header parameters. This overrides the `header` set in the resource block.
 - `url_locator` (String) Specifies how to discover the polling url. The format can be one of `header.path` (use the property at `path` in response header), `body.path` (use the property at `path` in response body) or `exact.value` (use the exact `value`). When absent, the resource's path is used for polling.
 
@@ -136,7 +139,7 @@ Required:
 
 Optional:
 
-- `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
+- `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second. Defaults to `10`.
 - `header` (Map of String) The header parameters. This overrides the `header` set in the resource block.
 - `url_locator` (String) Specifies how to discover the polling url. The format can be one of `header.path` (use the property at `path` in response header), `body.path` (use the property at `path` in response body) or `exact.value` (use the exact `value`). When absent, the resource's path is used for polling.
 
@@ -172,7 +175,7 @@ Required:
 
 Optional:
 
-- `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
+- `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second. Defaults to `10`.
 - `header` (Map of String) The header parameters. This overrides the `header` set in the resource block.
 - `query` (Map of List of String) The query parameters. This overrides the `query` set in the resource block.
 
@@ -208,7 +211,7 @@ Required:
 
 Optional:
 
-- `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
+- `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second. Defaults to `10`.
 - `header` (Map of String) The header parameters. This overrides the `header` set in the resource block.
 - `path` (String) The path used to query readiness, relative to the `base_url` of the provider. By default, the `id` of this resource is used.
 - `query` (Map of List of String) The query parameters. This overrides the `query` set in the resource block.
@@ -245,13 +248,95 @@ Required:
 
 Optional:
 
-- `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second.
+- `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second. Defaults to `10`.
 - `header` (Map of String) The header parameters. This overrides the `header` set in the resource block.
 - `path` (String) The path used to query readiness, relative to the `base_url` of the provider. By default, the `id` of this resource is used.
 - `query` (Map of List of String) The query parameters. This overrides the `query` set in the resource block.
 
 <a id="nestedatt--precheck_update--api--status"></a>
 ### Nested Schema for `precheck_update.api.status`
+
+Required:
+
+- `success` (String) The expected status sentinel for suceess status.
+
+Optional:
+
+- `pending` (List of String) The expected status sentinels for pending status.
+
+
+
+
+<a id="nestedatt--retry_create"></a>
+### Nested Schema for `retry_create`
+
+Required:
+
+- `status` (Attributes) The expected status sentinels. (see [below for nested schema](#nestedatt--retry_create--status))
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the gjson syntax. In most case, you shall use `code`, as you most not expect a write-like operation to perform multiple times.
+
+Optional:
+
+- `count` (Number) The maximum allowed retries. Defaults to `3`.
+- `max_wait_in_sec` (Number) The maximum allowed retry wait time. Defaults to `3600`.
+- `wait_in_sec` (Number) The initial retry wait time between two retries in second, if there is no `Retry-After` in the response header, or the `Retry-After` is less than this. The wait time will be increased in capped exponential backoff with jitter, at most up to `max_wait_in_sec` (if not null). Defaults to `1`.
+
+<a id="nestedatt--retry_create--status"></a>
+### Nested Schema for `retry_create.status`
+
+Required:
+
+- `success` (String) The expected status sentinel for suceess status.
+
+Optional:
+
+- `pending` (List of String) The expected status sentinels for pending status.
+
+
+
+<a id="nestedatt--retry_delete"></a>
+### Nested Schema for `retry_delete`
+
+Required:
+
+- `status` (Attributes) The expected status sentinels. (see [below for nested schema](#nestedatt--retry_delete--status))
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the gjson syntax. In most case, you shall use `code`, as you most not expect a write-like operation to perform multiple times.
+
+Optional:
+
+- `count` (Number) The maximum allowed retries. Defaults to `3`.
+- `max_wait_in_sec` (Number) The maximum allowed retry wait time. Defaults to `3600`.
+- `wait_in_sec` (Number) The initial retry wait time between two retries in second, if there is no `Retry-After` in the response header, or the `Retry-After` is less than this. The wait time will be increased in capped exponential backoff with jitter, at most up to `max_wait_in_sec` (if not null). Defaults to `1`.
+
+<a id="nestedatt--retry_delete--status"></a>
+### Nested Schema for `retry_delete.status`
+
+Required:
+
+- `success` (String) The expected status sentinel for suceess status.
+
+Optional:
+
+- `pending` (List of String) The expected status sentinels for pending status.
+
+
+
+<a id="nestedatt--retry_update"></a>
+### Nested Schema for `retry_update`
+
+Required:
+
+- `status` (Attributes) The expected status sentinels. (see [below for nested schema](#nestedatt--retry_update--status))
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the gjson syntax. In most case, you shall use `code`, as you most not expect a write-like operation to perform multiple times.
+
+Optional:
+
+- `count` (Number) The maximum allowed retries. Defaults to `3`.
+- `max_wait_in_sec` (Number) The maximum allowed retry wait time. Defaults to `3600`.
+- `wait_in_sec` (Number) The initial retry wait time between two retries in second, if there is no `Retry-After` in the response header, or the `Retry-After` is less than this. The wait time will be increased in capped exponential backoff with jitter, at most up to `max_wait_in_sec` (if not null). Defaults to `1`.
+
+<a id="nestedatt--retry_update--status"></a>
+### Nested Schema for `retry_update.status`
 
 Required:
 

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -65,6 +65,7 @@ resource "restful_resource" "rg" {
 - `read_selector` (String) A selector in [gjson query syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md#queries) query syntax, that is used when read returns a collection of resources, to select exactly one member resource of from it. By default, the whole response body is used as the body.
 - `retry_create` (Attributes) The retry option for the "Create (i.e. PUT/POST)" operation (see [below for nested schema](#nestedatt--retry_create))
 - `retry_delete` (Attributes) The retry option for the "Delete (i.e. DELETE)" operation (see [below for nested schema](#nestedatt--retry_delete))
+- `retry_read` (Attributes) The retry option for the "Read (i.e. GET, but not include the `precheck_xxx`/`poll_xxx`)" operation (see [below for nested schema](#nestedatt--retry_read))
 - `retry_update` (Attributes) The retry option for the "Update (i.e. PUT/PATCH/POST)" operation (see [below for nested schema](#nestedatt--retry_update))
 - `update_method` (String) The method used to update the resource. Possible values are `PUT`, `POST`, and `PATCH`. This overrides the `update_method` set in the provider block (defaults to PUT).
 - `update_path` (String) The API path used to update the resource. The `id` is used instead if `update_path` is absent. The path can be string literal, or combined by followings: `$(path)` expanded to `path`, `$(body.x.y.z)` expands to the `x.y.z` property (urlencoded) in API body, `#(body.id)` expands to the `id` property, with `base_url` prefix trimmed.
@@ -310,6 +311,33 @@ Optional:
 
 <a id="nestedatt--retry_delete--status"></a>
 ### Nested Schema for `retry_delete.status`
+
+Required:
+
+- `success` (String) The expected status sentinel for suceess status.
+
+Optional:
+
+- `pending` (List of String) The expected status sentinels for pending status.
+
+
+
+<a id="nestedatt--retry_read"></a>
+### Nested Schema for `retry_read`
+
+Required:
+
+- `status` (Attributes) The expected status sentinels. (see [below for nested schema](#nestedatt--retry_read--status))
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the gjson syntax. In most case, you shall use `code`, as you most not expect a write-like operation to perform multiple times.
+
+Optional:
+
+- `count` (Number) The maximum allowed retries. Defaults to `3`.
+- `max_wait_in_sec` (Number) The maximum allowed retry wait time. Defaults to `3600`.
+- `wait_in_sec` (Number) The initial retry wait time between two retries in second, if there is no `Retry-After` in the response header, or the `Retry-After` is less than this. The wait time will be increased in capped exponential backoff with jitter, at most up to `max_wait_in_sec` (if not null). Defaults to `1`.
+
+<a id="nestedatt--retry_read--status"></a>
+### Nested Schema for `retry_read.status`
 
 Required:
 

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.2 // indirect
-	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/net v0.17.0
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -199,9 +199,15 @@ func (c *Client) Create(ctx context.Context, path string, body interface{}, opt 
 type ReadOption struct {
 	Query  Query
 	Header Header
+	Retry  *RetryOption
 }
 
 func (c *Client) Read(ctx context.Context, path string, opt ReadOption) (*resty.Response, error) {
+	if opt.Retry != nil {
+		c.setRetry(*opt.Retry)
+		defer c.resetRetry()
+	}
+
 	req := c.R().SetContext(ctx)
 	req.SetQueryParamsFromValues(url.Values(opt.Query))
 	req.SetHeaders(opt.Header)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"strings"
+	"time"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -109,13 +111,76 @@ func New(ctx context.Context, baseURL string, opt *BuildOption) (*Client, error)
 	return &Client{client}, nil
 }
 
+type RetryOption struct {
+	StatusLocator ValueLocator
+	Status        PollingStatus
+	Count         int
+	WaitTime      time.Duration
+	MaxWaitTime   time.Duration
+}
+
+func (c *Client) resetRetry() {
+	c.RetryCount = 0
+	c.RetryWaitTime = 0
+	c.RetryMaxWaitTime = 0
+	c.RetryAfter = nil
+	c.RetryConditions = nil
+}
+
+func (c *Client) setRetry(opt RetryOption) {
+	c.RetryCount = opt.Count
+	c.RetryWaitTime = opt.WaitTime
+	c.RetryMaxWaitTime = opt.MaxWaitTime
+	c.RetryAfter = func(c *resty.Client, r *resty.Response) (time.Duration, error) {
+		dur := r.Header().Get("Retry-After")
+		if dur == "" {
+			// returning 0 will make the resty retry to using the backoff based on wait time, count and max wait time
+			return 0, nil
+		}
+		d, err := time.ParseDuration(dur + "s")
+		if err != nil {
+			return 0, fmt.Errorf("invalid Retry-After value in the initiated response: %s", dur)
+		}
+		return d, nil
+	}
+	c.RetryConditions = []resty.RetryConditionFunc{
+		func(r *resty.Response, err error) bool {
+			if err != nil {
+				return true
+			}
+
+			status := opt.StatusLocator.LocateValueInResp(*r)
+			if status == "" {
+				return false
+			}
+			// We tolerate case difference here to be pragmatic.
+			if strings.EqualFold(status, opt.Status.Success) {
+				return false
+			}
+
+			for _, ps := range opt.Status.Pending {
+				if strings.EqualFold(status, ps) {
+					return true
+				}
+			}
+
+			return false
+		},
+	}
+}
+
 type CreateOption struct {
 	Method string
 	Query  Query
 	Header Header
+	Retry  *RetryOption
 }
 
 func (c *Client) Create(ctx context.Context, path string, body interface{}, opt CreateOption) (*resty.Response, error) {
+	if opt.Retry != nil {
+		c.setRetry(*opt.Retry)
+		defer c.resetRetry()
+	}
 	req := c.R().SetContext(ctx).SetBody(body)
 	req.SetQueryParamsFromValues(url.Values(opt.Query))
 	req.SetHeaders(opt.Header)
@@ -132,8 +197,6 @@ func (c *Client) Create(ctx context.Context, path string, body interface{}, opt 
 }
 
 type ReadOption struct {
-	// The http method used for reading, which defaults to "GET"
-	Method string
 	Query  Query
 	Header Header
 }
@@ -143,16 +206,7 @@ func (c *Client) Read(ctx context.Context, path string, opt ReadOption) (*resty.
 	req.SetQueryParamsFromValues(url.Values(opt.Query))
 	req.SetHeaders(opt.Header)
 
-	switch opt.Method {
-	case "", "GET":
-		return req.Get(path)
-	case "HEAD":
-		return req.Head(path)
-	case "POST":
-		return req.Post(path)
-	default:
-		return nil, fmt.Errorf("unknown read method: %s", opt.Method)
-	}
+	return req.Get(path)
 }
 
 type UpdateOption struct {
@@ -160,9 +214,15 @@ type UpdateOption struct {
 	MergePatchDisabled bool
 	Query              Query
 	Header             Header
+	Retry              *RetryOption
 }
 
 func (c *Client) Update(ctx context.Context, path string, body interface{}, opt UpdateOption) (*resty.Response, error) {
+	if opt.Retry != nil {
+		c.setRetry(*opt.Retry)
+		defer c.resetRetry()
+	}
+
 	req := c.R().SetContext(ctx).SetBody(body)
 	req.SetQueryParamsFromValues(url.Values(opt.Query))
 	req.SetHeaders(opt.Header)
@@ -181,13 +241,18 @@ func (c *Client) Update(ctx context.Context, path string, body interface{}, opt 
 }
 
 type DeleteOption struct {
-	Method  string
-	Query   Query
-	Header  Header
-	PollOpt *PollOption
+	Method string
+	Query  Query
+	Header Header
+	Retry  *RetryOption
 }
 
 func (c *Client) Delete(ctx context.Context, path string, opt DeleteOption) (*resty.Response, error) {
+	if opt.Retry != nil {
+		c.setRetry(*opt.Retry)
+		defer c.resetRetry()
+	}
+
 	req := c.R().SetContext(ctx)
 	req.SetQueryParamsFromValues(url.Values(opt.Query))
 	req.SetHeaders(opt.Header)
@@ -206,9 +271,15 @@ type OperationOption struct {
 	Method string
 	Query  Query
 	Header Header
+	Retry  *RetryOption
 }
 
 func (c *Client) Operation(ctx context.Context, path string, body interface{}, opt OperationOption) (*resty.Response, error) {
+	if opt.Retry != nil {
+		c.setRetry(*opt.Retry)
+		defer c.resetRetry()
+	}
+
 	req := c.R().SetContext(ctx)
 	if body != "" {
 		req.SetBody(body)
@@ -228,5 +299,35 @@ func (c *Client) Operation(ctx context.Context, path string, body interface{}, o
 		return req.Delete(path)
 	default:
 		return nil, fmt.Errorf("unknown create method: %s", opt.Method)
+	}
+}
+
+type ReadOptionDS struct {
+	// Method used for reading, which defaults to GET
+	Method string
+	Query  Query
+	Header Header
+	Retry  *RetryOption
+}
+
+func (c *Client) ReadDS(ctx context.Context, path string, opt ReadOptionDS) (*resty.Response, error) {
+	if opt.Retry != nil {
+		c.setRetry(*opt.Retry)
+		defer c.resetRetry()
+	}
+
+	req := c.R().SetContext(ctx)
+	req.SetQueryParamsFromValues(url.Values(opt.Query))
+	req.SetHeaders(opt.Header)
+
+	switch opt.Method {
+	case "", "GET":
+		return req.Get(path)
+	case "POST":
+		return req.Post(path)
+	case "HEAD":
+		return req.Head(path)
+	default:
+		return nil, fmt.Errorf("unknown read (ds) method: %s", opt.Method)
 	}
 }

--- a/internal/defaults/default.go
+++ b/internal/defaults/default.go
@@ -1,0 +1,9 @@
+package defaults
+
+import "time"
+
+const (
+	RetryWaitTime    = time.Second
+	RetryMaxWaitTime = time.Hour
+	RetryCount       = 3
+)

--- a/internal/provider/api_option.go
+++ b/internal/provider/api_option.go
@@ -114,6 +114,14 @@ func (opt apiOption) ForResourceRead(ctx context.Context, d resourceData) (*clie
 		Query:  opt.Query.Clone().TakeOrSelf(ctx, d.Query),
 		Header: opt.Header.Clone().TakeOrSelf(ctx, d.Header),
 	}
+
+	if !d.RetryRead.IsNull() && !d.RetryRead.IsUnknown() {
+		retryOpt, diags := opt.forRetry(ctx, d.RetryRead)
+		if diags.HasError() {
+			return nil, diags
+		}
+		out.Retry = retryOpt
+	}
 	return &out, nil
 }
 

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -28,6 +28,7 @@ type dataSourceData struct {
 	OutputAttrs   types.Set    `tfsdk:"output_attrs"`
 	AllowNotExist types.Bool   `tfsdk:"allow_not_exist"`
 	Precheck      types.List   `tfsdk:"precheck"`
+	Retry         types.Object `tfsdk:"retry"`
 	Output        types.String `tfsdk:"output"`
 }
 
@@ -82,6 +83,7 @@ func (d *DataSource) Schema(ctx context.Context, req datasource.SchemaRequest, r
 				Optional:            true,
 			},
 			"precheck": precheckAttribute("Read", true, ""),
+			"retry":    retryAttribute("Read"),
 			"output": schema.StringAttribute{
 				Description:         "The response body after reading the resource.",
 				MarkdownDescription: "The response body after reading the resource.",
@@ -141,9 +143,10 @@ func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 		OutputAttrs:   config.OutputAttrs,
 		AllowNotExist: config.AllowNotExist,
 		Precheck:      config.Precheck,
+		Retry:         config.Retry,
 	}
 
-	response, err := c.Read(ctx, config.ID.ValueString(), *opt)
+	response, err := c.ReadDS(ctx, config.ID.ValueString(), *opt)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error to call Read",

--- a/internal/provider/operation_resource.go
+++ b/internal/provider/operation_resource.go
@@ -34,6 +34,7 @@ type operationResourceData struct {
 	Header   types.Map    `tfsdk:"header"`
 	Precheck types.List   `tfsdk:"precheck"`
 	Poll     types.Object `tfsdk:"poll"`
+	Retry    types.Object `tfsdk:"retry"`
 	Output   types.String `tfsdk:"output"`
 }
 
@@ -95,6 +96,7 @@ func (r *OperationResource) Schema(ctx context.Context, req resource.SchemaReque
 			},
 			"precheck": precheckAttribute("API", false, "By default, the `path` of this resource is used."),
 			"poll":     pollAttribute("API"),
+			"retry":    retryAttribute("API"),
 			"output": schema.StringAttribute{
 				Description:         "The response body.",
 				MarkdownDescription: "The response body.",

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -65,6 +65,7 @@ type resourceData struct {
 	PollDelete types.Object `tfsdk:"poll_delete"`
 
 	RetryCreate types.Object `tfsdk:"retry_create"`
+	RetryRead   types.Object `tfsdk:"retry_read"`
 	RetryUpdate types.Object `tfsdk:"retry_update"`
 	RetryDelete types.Object `tfsdk:"retry_delete"`
 
@@ -405,6 +406,7 @@ func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 			"precheck_delete": precheckAttribute("Delete", false, "By default, the `id` of this resource is used."),
 
 			"retry_create": retryAttribute("Create (i.e. PUT/POST)"),
+			"retry_read":   retryAttribute("Read (i.e. GET, but not include the `precheck_xxx`/`poll_xxx`)"),
 			"retry_update": retryAttribute("Update (i.e. PUT/PATCH/POST)"),
 			"retry_delete": retryAttribute("Delete (i.e. DELETE)"),
 
@@ -508,12 +510,12 @@ func (r *Resource) ValidateConfig(ctx context.Context, req resource.ValidateConf
 
 func (r *Resource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	if req.Plan.Raw.IsNull() {
-		// // If the entire plan is null, the resource is planned for destruction.
+		// If the entire plan is null, the resource is planned for destruction.
 		return
 	}
 
 	if req.State.Raw.IsNull() {
-		// // If the entire state is null, the resource is planned for creation.
+		// If the entire state is null, the resource is planned for creation.
 		return
 	}
 	var plan resourceData


### PR DESCRIPTION
This PR adds support of:

- `retry_(create|read|update|delete)` for `restful_resource` resource
- `retry` for `restful_resource` data source
- `retry` for `restful_operation` resource

In the meanwhile, it splits the `Client.Read` into `Client.Read` (for the `restful_resource` resource's read) and `Client.ReadDS` (for the `restful_resource` data source's read). Similarly, the read option for these two methods are split. ~This is due to only the `Client.ReadDS`'s option shall allow the `RetryOption`, while the resource's read shouldn't (as we only retry on the CUD). Though, if later we have a valid scenario where the resource's read also benefit on retrying, we can further consider adding a `retry_read` for it.~

Fix #74 
Fix #33 