### PR TITLE
`precheck|poll` expose API error if the `status_locator` is not `code`

### DIFF
--- a/internal/client/async.go
+++ b/internal/client/async.go
@@ -180,6 +180,14 @@ PollingLoop:
 			return fmt.Errorf("polling %s: %v", f.URL, err)
 		}
 
+		// In case this is status_locator is not a code locator, then we shall firstly ensure the GET succeeded,
+		// to avoid the status retrieving error hides the actual GET error.
+		if _, ok := f.StatusLocator.(CodeLocator); !ok {
+			if !resp.IsSuccess() {
+				return fmt.Errorf("polling returns %d: %s", resp.StatusCode(), string(resp.Body()))
+			}
+		}
+
 		status := f.StatusLocator.LocateValueInResp(*resp)
 		if status == "" {
 			return fmt.Errorf("No status value found from %s", f.StatusLocator)


### PR DESCRIPTION
This PR modifies the error handling of `precheck(_xxx).*.api` and `poll(_xxx)`, in which the `status_locator` is not `code`. This means it is polling a value in either in the header or in the body, which assumes the `GET` operation of this poll succeeded. Therefore, we shall add the code to ensure this, as otherwise if the `GET` failed but we didn't check, the error message will be a bit out-of-topic (see #76 for an example).

Fix #76 