### PR TITLE
Provider: Add mTLS support

### DIFF
--- a/docs/data-sources/resource.md
+++ b/docs/data-sources/resource.md
@@ -101,3 +101,5 @@ Required:
 Optional:
 
 - `pending` (List of String) The expected status sentinels for pending status.
+
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,15 +118,37 @@ provider "restful" {
 
 ### Optional
 
-- `cookie_enabled` (Boolean) Save cookies during API contracting. Defaults to `false`.
+- `client` (Attributes) The client configuration (see [below for nested schema](#nestedatt--client))
 - `create_method` (String) The method used to create the resource. Possible values are `PUT` and `POST`. Defaults to `POST`.
 - `delete_method` (String) The method used to delete the resource. Possible values are `DELETE` and `POST`. Defaults to `DELETE`.
 - `header` (Map of String) The header parameters that are applied to each request.
 - `merge_patch_disabled` (Boolean) Whether to use a JSON Merge Patch as the request body in the PATCH update? Defaults to `false`. This is only effective when `update_method` is set to `PATCH`.
 - `query` (Map of List of String) The query parameters that are applied to each request.
 - `security` (Attributes) The OpenAPI security scheme that is be used for auth. Only one of `http`, `apikey` and `oauth2` can be specified. (see [below for nested schema](#nestedatt--security))
-- `tls_insecure_skip_verify` (Boolean) Whether a client verifies the server's certificate chain and host name. Defaults to `false`.
 - `update_method` (String) The method used to update the resource. Possible values are `PUT` and `PATCH`. Defaults to `PUT`.
+
+<a id="nestedatt--client"></a>
+### Nested Schema for `client`
+
+Optional:
+
+- `certificates` (Attributes List) The client certificates for mTLS. (see [below for nested schema](#nestedatt--client--certificates))
+- `cookie_enabled` (Boolean) Save cookies during API contracting. Defaults to `false`.
+- `root_ca_certificate_files` (List of String) The list of certificate file paths of root certificate authorities that clients use when verifying server certificates. If not specified, TLS uses the host's root CA set. Conflicts with `root_ca_certificate_files`.
+- `root_ca_certificates` (List of String) The list of certificates of root certificate authorities that clients use when verifying server certificates. If not specified, TLS uses the host's root CA set. Conflicts with `root_ca_certificate_files`.
+- `tls_insecure_skip_verify` (Boolean) Whether a client verifies the server's certificate chain and host name. Defaults to `false`.
+
+<a id="nestedatt--client--certificates"></a>
+### Nested Schema for `client.certificates`
+
+Optional:
+
+- `certificate` (String) The client certificate for mTLS. Conflicts with `certificate_file`. Requires `key_file` or `key`.
+- `certificate_file` (String) The path of the client certificate file for mTLS. Conflicts with `certificate`. Requires `key_file` or `key`.
+- `key` (String) The client private key for mTLS. Conflicts with `key_file`.
+- `key_file` (String) The path of the client private key file for mTLS. Conflicts with `key`. Requires `certificate_file` or `certificate`.
+
+
 
 <a id="nestedatt--security"></a>
 ### Nested Schema for `security`

--- a/docs/resources/operation.md
+++ b/docs/resources/operation.md
@@ -238,3 +238,5 @@ Required:
 Optional:
 
 - `pending` (List of String) The expected status sentinels for pending status.
+
+

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -93,11 +93,9 @@ func New(ctx context.Context, baseURL string, opt *BuildOption) (*Client, error)
 		httpClient.Jar = cookieJar
 	}
 
-	client := resty.New()
+	client := resty.NewWithClient(httpClient)
 	if opt.Security != nil {
-		var err error
-		client, err = opt.Security.newClient(ctx, httpClient)
-		if err != nil {
+		if err := opt.Security.configureClient(ctx, client); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/provider/data_source_mtls_test.go
+++ b/internal/provider/data_source_mtls_test.go
@@ -1,0 +1,200 @@
+package provider_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/magodo/terraform-provider-restful/internal/acceptance"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDataSourceMTLS(t *testing.T) {
+	serverTLSConfig, caCert, clientCert, clientKey, err := certSetup()
+	require.NoError(t, err)
+
+	resp := "response"
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, resp)
+	}))
+	server.TLS = serverTLSConfig
+	server.StartTLS()
+	defer server.Close()
+
+	// Test client via this provider
+	addr := "data.restful_resource.test"
+	// For some unknown reason, we can't mark this test as Parallel, as otherwise, either the regular http call or the mtls server call will fail with certificate signed by unknown CA.
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acceptance.ProviderFactory(),
+		Steps: []resource.TestStep{
+			{
+				Config: mtlsConfig(server.URL, caCert, clientCert, clientKey),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(addr, "output", resp),
+				),
+			},
+		},
+	})
+}
+
+func mtlsConfig(url string, caCert, clientCert, clientKey []byte) string {
+	return fmt.Sprintf(`
+provider "restful" {
+  base_url = %q
+  client = {
+	root_ca_certificates = [%q]
+    certificates = [
+      {
+        certificate = %q
+        key         = %q
+      },
+    ]
+  }
+}
+data "restful_resource" "test" {
+  id = "/"
+}
+`, url, caCert, clientCert, clientKey)
+}
+
+func certSetup() (serverTLSConf *tls.Config, caCert, clientCert, clientKey []byte, err error) {
+	// set up our CA certificate
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(2019),
+		Subject: pkix.Name{
+			Organization:  []string{"Company, INC."},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{"San Francisco"},
+			StreetAddress: []string{"Golden Gate Bridge"},
+			PostalCode:    []string{"94016"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	// create our private and public key
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	// create the CA
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	// pem encode
+	caPEM := new(bytes.Buffer)
+	pem.Encode(caPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+
+	caPrivKeyPEM := new(bytes.Buffer)
+	pem.Encode(caPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey),
+	})
+
+	certpool := x509.NewCertPool()
+	certpool.AppendCertsFromPEM(caPEM.Bytes())
+
+	// set up our server certificate
+	srvCertPEM, srvKeyPEM, err := generateCertificate(ca, caPrivKey, &x509.Certificate{
+		SerialNumber: big.NewInt(2019),
+		Subject: pkix.Name{
+			Organization:  []string{"Company, INC."},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{"San Francisco"},
+			StreetAddress: []string{"Golden Gate Bridge"},
+			PostalCode:    []string{"94016"},
+		},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	})
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	serverCert, err := tls.X509KeyPair(srvCertPEM, srvKeyPEM)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	serverTLSConf = &tls.Config{
+		ClientCAs:    certpool,
+		Certificates: []tls.Certificate{serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+	}
+
+	cliCertPEM, cliKeyPEM, err := generateCertificate(ca, caPrivKey, &x509.Certificate{
+		SerialNumber: big.NewInt(2019),
+		Subject: pkix.Name{
+			Organization:  []string{"Company, INC."},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{"San Francisco"},
+			StreetAddress: []string{"Golden Gate Bridge"},
+			PostalCode:    []string{"94016"},
+		},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	})
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	return serverTLSConf, caPEM.Bytes(), cliCertPEM, cliKeyPEM, nil
+}
+
+func generateCertificate(caCert *x509.Certificate, caPrivKey any, cert *x509.Certificate) (certificate, key []byte, err error) {
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, caCert, &certPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM := new(bytes.Buffer)
+	pem.Encode(certPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+
+	certPrivKeyPEM := new(bytes.Buffer)
+	pem.Encode(certPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(certPrivKey),
+	})
+
+	return certPEM.Bytes(), certPrivKeyPEM.Bytes(), nil
+}


### PR DESCRIPTION
This PR adds mTLS support. It also introduce a breaking change to re-structure the `provider` configuration:

- Introduce a new `client` single nested attribute
- Moves the `cookie_enabled` and `tls_insecure_skip_verify` from top-level under `client`
- Add a new list nested attribute `client.certificates`, which contains:
  - `certificate`
  - `certificate_file`
  - `key`
  - `key_file`
- Add two new attributes `client.root_ca_certificates` and `client.root_ca_certificate_files` 

## Issues Fixed

- Fix #7 
- Fix #59