### PR TITLE
`restful_resource` - `(read_)selector` handle selected part is removed out-of-band

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -147,8 +147,8 @@ func (c *Client) setRetry(opt RetryOption) {
 				return true
 			}
 
-			status := opt.StatusLocator.LocateValueInResp(*r)
-			if status == "" {
+			status, ok := opt.StatusLocator.LocateValueInResp(*r)
+			if !ok {
 				return false
 			}
 			// We tolerate case difference here to be pragmatic.

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/tidwall/gjson"
+	"github.com/magodo/terraform-provider-restful/internal/client"
 )
 
 type DataSource struct {
@@ -170,23 +170,23 @@ func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 
 	b := response.Body()
 
-	if config.Selector.ValueString() != "" {
-		result := gjson.GetBytes(b, config.Selector.ValueString())
-		if !result.Exists() {
+	if sel := config.Selector.ValueString(); sel != "" {
+		bodyLocator := client.BodyLocator(sel)
+		sb, ok := bodyLocator.LocateValueInResp(*response)
+		if !ok {
+			if config.AllowNotExist.ValueBool() {
+				// Setting the input attributes to the state anyway
+				diags = resp.State.Set(ctx, state)
+				resp.Diagnostics.Append(diags...)
+				return
+			}
 			resp.Diagnostics.AddError(
-				fmt.Sprintf("Failed to select resource from response"),
-				fmt.Sprintf("Can't find resource with query %q", config.Selector.ValueString()),
+				fmt.Sprintf("`selector` failed to select from the response"),
+				string(response.Body()),
 			)
 			return
 		}
-		if len(result.Array()) > 1 {
-			resp.Diagnostics.AddError(
-				fmt.Sprintf("Failed to select resource from response"),
-				fmt.Sprintf("Multiple resources with query %q found (%d)", config.Selector.ValueString(), len(result.Array())),
-			)
-			return
-		}
-		b = []byte(result.Array()[0].Raw)
+		b = []byte(sb)
 	}
 
 	// Set output

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -658,7 +658,15 @@ func (r Resource) Create(ctx context.Context, req resource.CreateRequest, resp *
 	if sel := plan.CreateSelector.ValueString(); sel != "" {
 		// Guaranteed by schema
 		bodyLocator := client.BodyLocator(sel)
-		b = []byte(bodyLocator.LocateValueInResp(*response))
+		sb, ok := bodyLocator.LocateValueInResp(*response)
+		if !ok {
+			resp.Diagnostics.AddError(
+				fmt.Sprintf("`create_selector` failed to select from the response"),
+				string(response.Body()),
+			)
+			return
+		}
+		b = []byte(sb)
 	}
 
 	// Construct the resource id, which is used as the path to read the resource later on. By default, it is the same as the "path", unless "read_path" is specified.
@@ -776,7 +784,14 @@ func (r Resource) Read(ctx context.Context, req resource.ReadRequest, resp *reso
 	if sel := state.ReadSelector.ValueString(); sel != "" {
 		// Guaranteed by schema
 		bodyLocator := client.BodyLocator(sel)
-		b = []byte(bodyLocator.LocateValueInResp(*response))
+		sb, ok := bodyLocator.LocateValueInResp(*response)
+		// This means the tracked resource selected (filtered) from the response now disappears (deleted out of band).
+		if !ok {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		b = []byte(sb)
+
 	}
 
 	var writeOnlyAttributes []string


### PR DESCRIPTION
For some *composite* API responses, where only the subset of the response represents the resource that the user currently tracks. In this case, users use `(read_)selector` to select the tracked resource from this response. Currently, the provider will always try to apply the selector (query) on the response and return the query result, even if queried out nothing, in which case the follow up modify body process in read function will fail with errors like below:

```
│ Error: Modifying `body` during Read
...
│ unmarshal the body "": unexpected end of JSON input
```

This can be triggered by several cases, e.g.:

1. The selector is not correctly composed
2. The resource is removed out-of-band

This PR changes the behavior when the query returns nothing, that we will regard this resource as non exist. This has no problem for the 2nd case, but might introduce in-convenience for the 1st case, as user now will need to either import the resource or remove it out-of-band...

This change covers:

- Resource `restful_resource` - `read_selector`
- Data Source `restful_resource` - `selector`

Fix #92