### PR TITLE
`restful_resource` - `[read|update_delete]_path` builder pattern supports `$(body)`

### DIFF
--- a/internal/buildpath/path.go
+++ b/internal/buildpath/path.go
@@ -37,6 +37,10 @@ func BuildPath(pattern string, baseURL, path string, body []byte) (string, error
 			out = strings.ReplaceAll(out, match[0], path)
 			continue
 		}
+		if match[2] == "body" {
+			out = strings.ReplaceAll(out, match[0], string(body))
+			continue
+		}
 		if strings.HasPrefix(match[2], "body.") {
 			jsonPath := strings.TrimPrefix(match[2], "body.")
 			prop := gjson.GetBytes(body, jsonPath)

--- a/internal/provider/resource_dead_simple_json_server_test.go
+++ b/internal/provider/resource_dead_simple_json_server_test.go
@@ -3,8 +3,10 @@ package provider_test
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
-	"os"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -13,35 +15,42 @@ import (
 	"github.com/magodo/terraform-provider-restful/internal/client"
 )
 
-const RESTFUL_DEAD_SIMPLE_SERVER_URL = "RESTFUL_DEAD_SIMPLE_SERVER_URL"
+type deadSimpleServerData struct{}
 
-type deadSimpleServerData struct {
-	url string
-}
-
-func (d deadSimpleServerData) precheck(t *testing.T) {
-	if d.url == "" {
-		t.Skipf("%q is not specified", RESTFUL_DEAD_SIMPLE_SERVER_URL)
-	}
-	return
-}
-
-func newDeadSimpleServerData() deadSimpleServerData {
-	return deadSimpleServerData{
-		url: os.Getenv(RESTFUL_DEAD_SIMPLE_SERVER_URL),
-	}
-}
-
-func TestResource_DeadSimpleServer_Basic(t *testing.T) {
+func TestResource_DeadSimpleServer_ObjectArray(t *testing.T) {
 	addr := "restful_resource.test"
-	d := newDeadSimpleServerData()
+
+	type object struct {
+		b  []byte
+		id string
+	}
+	var obj *object
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PUT":
+			b, _ := io.ReadAll(r.Body)
+			r.Body.Close()
+			obj = &object{b: b, id: r.URL.String()}
+			return
+		case "GET":
+			if obj == nil || r.URL.String() != obj.id {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Write(obj.b)
+			return
+		case "DELETE":
+			obj = nil
+			return
+		}
+	}))
+	d := deadSimpleServerData{}
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { d.precheck(t) },
-		CheckDestroy:             d.CheckDestroy(addr),
+		CheckDestroy:             d.CheckDestroy(srv.URL, addr),
 		ProtoV6ProviderFactories: acceptance.ProviderFactory(),
 		Steps: []resource.TestStep{
 			{
-				Config: d.basic("foo"),
+				Config: d.object_array(srv.URL, "foo"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(addr, "output"),
 				),
@@ -56,7 +65,7 @@ func TestResource_DeadSimpleServer_Basic(t *testing.T) {
 				},
 			},
 			{
-				Config: d.basic("bar"),
+				Config: d.object_array(srv.URL, "bar"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(addr, "output"),
 				),
@@ -74,9 +83,63 @@ func TestResource_DeadSimpleServer_Basic(t *testing.T) {
 	})
 }
 
-func (d deadSimpleServerData) CheckDestroy(addr string) func(*terraform.State) error {
+func TestResource_DeadSimpleServer_CreateRetString(t *testing.T) {
+	addr := "restful_resource.test"
+
+	type object struct {
+		b  []byte
+		id string
+	}
+	const id = "foo"
+	var obj *object
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PUT":
+			b, _ := io.ReadAll(r.Body)
+			r.Body.Close()
+			r.URL.Path, _ = url.JoinPath(r.URL.Path, id)
+			obj = &object{b: b, id: r.URL.String()}
+			w.Write([]byte(id))
+			return
+		case "GET":
+			if obj == nil || r.URL.String() != obj.id {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Write(obj.b)
+			return
+		case "DELETE":
+			obj = nil
+			return
+		}
+	}))
+	d := deadSimpleServerData{}
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             d.CheckDestroy(srv.URL, addr),
+		ProtoV6ProviderFactories: acceptance.ProviderFactory(),
+		Steps: []resource.TestStep{
+			{
+				Config: d.create_ret_string(srv.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(addr, "output"),
+				),
+			},
+			{
+				ResourceName:            addr,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"create_method", "read_path"},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					return fmt.Sprintf(`{"path": "/test", "id": "/test/%s", "body": {}}`, id), nil
+				},
+			},
+		},
+	})
+}
+
+func (d deadSimpleServerData) CheckDestroy(url, addr string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		c, err := client.New(context.TODO(), d.url, nil)
+		c, err := client.New(context.TODO(), url, nil)
 		if err != nil {
 			return err
 		}
@@ -97,7 +160,7 @@ func (d deadSimpleServerData) CheckDestroy(addr string) func(*terraform.State) e
 	}
 }
 
-func (d deadSimpleServerData) basic(v string) string {
+func (d deadSimpleServerData) object_array(url, v string) string {
 	return fmt.Sprintf(`
 provider "restful" {
   base_url = %q
@@ -112,5 +175,20 @@ resource "restful_resource" "test" {
   }
 ])
 }
-`, d.url, v)
+`, url, v)
+}
+
+func (d deadSimpleServerData) create_ret_string(url string) string {
+	return fmt.Sprintf(`
+provider "restful" {
+  base_url = %q
+}
+
+resource "restful_resource" "test" {
+  path = "/test"
+  create_method = "PUT"
+  read_path = "$(path)/$(body)"
+  body = "{}"
+}
+`, url)
 }


### PR DESCRIPTION
Fix #95