### PR TITLE
`restful_operation` - Supports `output` to be null

### DIFF
--- a/internal/dynamic/dynamic.go
+++ b/internal/dynamic/dynamic.go
@@ -92,6 +92,7 @@ func attrValueToJSON(val attr.Value) ([]byte, error) {
 	}
 }
 
+// FromJSON converts a JSON to dynamic types, instructed by the typ.
 func FromJSON(b []byte, typ attr.Type) (types.Dynamic, error) {
 	v, err := attrValueFromJSON(b, typ)
 	if err != nil {
@@ -280,8 +281,11 @@ func attrValueFromJSON(b []byte, typ attr.Type) (attr.Value, error) {
 // - []interface{}: tuple
 // - map[string]interface{}: object
 // - nil: null (dynamic)
-// Note the argument has to be a valid JSON byte. E.g. it returns error on nil (0-length bytes).
+// In case the input json is of zero-length, it returns null (dynamic).
 func FromJSONImplied(b []byte) (types.Dynamic, error) {
+	if len(b) == 0 {
+		return types.DynamicNull(), nil
+	}
 	_, v, err := attrValueFromJSONImplied(b)
 	if err != nil {
 		return types.Dynamic{}, err
@@ -347,8 +351,6 @@ func attrValueFromJSONImplied(b []byte) (attr.Type, attr.Value, error) {
 		return types.NumberType, types.NumberValue(big.NewFloat(v)), nil
 	case string:
 		return types.StringType, types.StringValue(v), nil
-	case nil:
-		return types.DynamicType, types.DynamicNull(), nil
 	default:
 		return nil, nil, fmt.Errorf("Unhandled type: %T", v)
 	}

--- a/internal/dynamic/dynamic_test.go
+++ b/internal/dynamic/dynamic_test.go
@@ -704,6 +704,11 @@ func TestFromJSONImplied(t *testing.T) {
 				),
 			),
 		},
+		{
+			name:   "empty",
+			input:  ``,
+			expect: types.DynamicNull(),
+		},
 	}
 
 	for _, tt := range cases {

--- a/internal/provider/operation_code_server_test.go
+++ b/internal/provider/operation_code_server_test.go
@@ -1,0 +1,53 @@
+package provider_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/magodo/terraform-provider-restful/internal/acceptance"
+)
+
+type codeServerOperation struct {
+	url string
+}
+
+func newCodeServerOperation(url string) codeServerOperation {
+	return codeServerOperation{url: url}
+}
+
+func TestOperation_CodeServer_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		return
+	}))
+
+	addr := "restful_operation.test"
+	d := newCodeServerOperation(srv.URL)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acceptance.ProviderFactory(),
+		Steps: []resource.TestStep{
+			{
+				Config: d.empty(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr(addr, "output"),
+				),
+			},
+		},
+	})
+}
+
+func (d codeServerOperation) empty() string {
+	return fmt.Sprintf(`
+provider "restful" {
+  base_url = %q
+}
+
+resource "restful_operation" "test" {
+  path = "posts"
+  method = "POST"
+  body = null
+}
+`, d.url)
+}

--- a/internal/provider/resource_code_server_test.go
+++ b/internal/provider/resource_code_server_test.go
@@ -18,7 +18,7 @@ import (
 
 type deadSimpleServerData struct{}
 
-func TestResource_DeadSimpleServer_ObjectArray(t *testing.T) {
+func TestResource_CodeServer_ObjectArray(t *testing.T) {
 	addr := "restful_resource.test"
 
 	type object struct {
@@ -84,7 +84,7 @@ func TestResource_DeadSimpleServer_ObjectArray(t *testing.T) {
 	})
 }
 
-func TestResource_DeadSimpleServer_CreateRetString(t *testing.T) {
+func TestResource_CodeServer_CreateRetString(t *testing.T) {
 	addr := "restful_resource.test"
 
 	type object struct {


### PR DESCRIPTION
Fix #99