### PR TITLE
`dynamic.ToJSON` handles unknown underlying value

### DIFF
--- a/internal/dynamic/dynamic.go
+++ b/internal/dynamic/dynamic.go
@@ -11,7 +11,7 @@ import (
 )
 
 func ToJSON(d types.Dynamic) ([]byte, error) {
-	if d.IsNull() {
+	if d.IsNull() || d.IsUnknown() {
 		return nil, nil
 	}
 	return attrValueToJSON(d.UnderlyingValue())
@@ -42,7 +42,7 @@ func attrMapToJSON(in map[string]attr.Value) (map[string]json.RawMessage, error)
 }
 
 func attrValueToJSON(val attr.Value) ([]byte, error) {
-	if val.IsNull() {
+	if val.IsNull() || val.IsUnknown() {
 		return json.Marshal(nil)
 	}
 	switch value := val.(type) {

--- a/internal/dynamic/dynamic_test.go
+++ b/internal/dynamic/dynamic_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/stretchr/testify/require"
 )
 
@@ -81,6 +82,8 @@ func TestToJSON(t *testing.T) {
 						"string": types.StringType,
 					},
 				},
+				"dynamic_unknwon": basetypes.DynamicType{},
+				"dynamic_null":    basetypes.DynamicType{},
 			},
 			map[string]attr.Value{
 				"bool":         types.BoolValue(true),
@@ -168,6 +171,8 @@ func TestToJSON(t *testing.T) {
 						"string": types.StringType,
 					},
 				),
+				"dynamic_unknwon": types.DynamicUnknown(),
+				"dynamic_null":    types.DynamicNull(),
 			},
 		),
 	)
@@ -203,7 +208,9 @@ func TestToJSON(t *testing.T) {
 		"string": "a"
 	},
 	"object_empty": {},
-	"object_null": null
+	"object_null": null,
+	"dynamic_unknwon": null,
+	"dynamic_null": null
 }`
 
 	b, err := ToJSON(input)


### PR DESCRIPTION
Fix #110