### PR TITLE
`restful_[operation|resource`: `precheck_[update|delete]` and `poll_[create|update|delete]` supports `$(body)` parameter for `status_locator`

### DIFF
--- a/docs/resources/operation.md
+++ b/docs/resources/operation.md
@@ -68,7 +68,7 @@ resource "restful_operation" "register_rp" {
 Required:
 
 - `status` (Attributes) The expected status sentinels for each polling state. (see [below for nested schema](#nestedatt--poll--status))
-- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md). The `path` can contain `$(body.x.y.z)` parameter that reference property from either the response body (for `Create`, after selector), and `state.output` (for `Read`/`Update`/`Delete`).
 
 Optional:
 
@@ -95,7 +95,7 @@ Optional:
 Required:
 
 - `status` (Attributes) The expected status sentinels for each polling state. (see [below for nested schema](#nestedatt--poll_delete--status))
-- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md). The `path` can contain `$(body.x.y.z)` parameter that reference property from either the response body (for `Create`, after selector), and `state.output` (for `Read`/`Update`/`Delete`).
 
 Optional:
 
@@ -167,7 +167,7 @@ Optional:
 Required:
 
 - `status` (Attributes) The expected status sentinels for each polling state. (see [below for nested schema](#nestedatt--precheck_delete--api--status))
-- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md). The `path` can contain `$(body.x.y.z)` parameter that reference property from the `state.output`.
 
 Optional:
 

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -86,7 +86,7 @@ resource "restful_resource" "rg" {
 Required:
 
 - `status` (Attributes) The expected status sentinels for each polling state. (see [below for nested schema](#nestedatt--poll_create--status))
-- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md). The `path` can contain `$(body.x.y.z)` parameter that reference property from either the response body (for `Create`, after selector), and `state.output` (for `Read`/`Update`/`Delete`).
 
 Optional:
 
@@ -113,7 +113,7 @@ Optional:
 Required:
 
 - `status` (Attributes) The expected status sentinels for each polling state. (see [below for nested schema](#nestedatt--poll_delete--status))
-- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md). The `path` can contain `$(body.x.y.z)` parameter that reference property from either the response body (for `Create`, after selector), and `state.output` (for `Read`/`Update`/`Delete`).
 
 Optional:
 
@@ -140,7 +140,7 @@ Optional:
 Required:
 
 - `status` (Attributes) The expected status sentinels for each polling state. (see [below for nested schema](#nestedatt--poll_update--status))
-- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md). The `path` can contain `$(body.x.y.z)` parameter that reference property from either the response body (for `Create`, after selector), and `state.output` (for `Read`/`Update`/`Delete`).
 
 Optional:
 
@@ -212,7 +212,7 @@ Optional:
 Required:
 
 - `status` (Attributes) The expected status sentinels for each polling state. (see [below for nested schema](#nestedatt--precheck_delete--api--status))
-- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md). The `path` can contain `$(body.x.y.z)` parameter that reference property from the `state.output`.
 
 Optional:
 
@@ -249,7 +249,7 @@ Optional:
 Required:
 
 - `status` (Attributes) The expected status sentinels for each polling state. (see [below for nested schema](#nestedatt--precheck_update--api--status))
-- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).
+- `status_locator` (String) Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md). The `path` can contain `$(body.x.y.z)` parameter that reference property from the `state.output`.
 
 Optional:
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -165,8 +165,6 @@ type CreateOption struct {
 }
 
 func (c *Client) Create(ctx context.Context, path string, body interface{}, opt CreateOption) (*resty.Response, error) {
-	c.SetLoggerContext(ctx)
-
 	req := c.R().SetContext(ctx).SetBody(body)
 	req.SetQueryParamsFromValues(url.Values(opt.Query))
 	req.SetHeaders(opt.Header)
@@ -190,8 +188,6 @@ type ReadOption struct {
 }
 
 func (c *Client) Read(ctx context.Context, path string, opt ReadOption) (*resty.Response, error) {
-	c.SetLoggerContext(ctx)
-
 	req := c.R().SetContext(ctx)
 	req.SetQueryParamsFromValues(url.Values(opt.Query))
 	req.SetHeaders(opt.Header)
@@ -207,8 +203,6 @@ type UpdateOption struct {
 }
 
 func (c *Client) Update(ctx context.Context, path string, body interface{}, opt UpdateOption) (*resty.Response, error) {
-	c.SetLoggerContext(ctx)
-
 	req := c.R().SetContext(ctx).SetBody(body)
 	req.SetQueryParamsFromValues(url.Values(opt.Query))
 	req.SetHeaders(opt.Header)
@@ -233,8 +227,6 @@ type DeleteOption struct {
 }
 
 func (c *Client) Delete(ctx context.Context, path string, opt DeleteOption) (*resty.Response, error) {
-	c.SetLoggerContext(ctx)
-
 	req := c.R().SetContext(ctx)
 	req.SetQueryParamsFromValues(url.Values(opt.Query))
 	req.SetHeaders(opt.Header)
@@ -256,8 +248,6 @@ type OperationOption struct {
 }
 
 func (c *Client) Operation(ctx context.Context, path string, body basetypes.DynamicValue, opt OperationOption) (*resty.Response, error) {
-	c.SetLoggerContext(ctx)
-
 	req := c.R().SetContext(ctx)
 	req.SetQueryParamsFromValues(url.Values(opt.Query))
 
@@ -314,8 +304,6 @@ type ReadOptionDS struct {
 }
 
 func (c *Client) ReadDS(ctx context.Context, path string, opt ReadOptionDS) (*resty.Response, error) {
-	c.SetLoggerContext(ctx)
-
 	req := c.R().SetContext(ctx)
 	req.SetQueryParamsFromValues(url.Values(opt.Query))
 	req.SetHeaders(opt.Header)

--- a/internal/provider/precheck.go
+++ b/internal/provider/precheck.go
@@ -10,56 +10,55 @@ import (
 	"github.com/magodo/terraform-provider-restful/internal/locks"
 )
 
-func precheck(ctx context.Context, c *client.Client, apiOpt apiOption, defaultPath string, defaultHeader client.Header, defaultQuery client.Query, prechecks basetypes.ListValue) (func(), diag.Diagnostics) {
+func precheck(ctx context.Context, c *client.Client, apiOpt apiOption, defaultPath string, defaultHeader client.Header, defaultQuery client.Query, prechecks basetypes.ListValue, body basetypes.DynamicValue) (func(), diag.Diagnostics) {
 	lockedNames := []string{}
-	if !prechecks.IsNull() {
-		var checks []precheckData
-		if diags := prechecks.ElementsAs(ctx, &checks, false); diags.HasError() {
-			return nil, diags
-		}
+	var checks []precheckData
+	if diags := prechecks.ElementsAs(ctx, &checks, false); diags.HasError() {
+		return nil, diags
+	}
 
-		for i, check := range checks {
-			switch {
-			case !check.Api.IsNull():
-				var d precheckDataApi
-				if diags := check.Api.As(ctx, &d, basetypes.ObjectAsOptions{}); diags.HasError() {
-					return nil, diags
-				}
-				opt, diags := apiOpt.ForPrecheck(ctx, defaultPath, defaultHeader, defaultQuery, d)
-				if diags.HasError() {
-					return nil, diags
-				}
-				p, err := client.NewPollableForPrecheck(*opt)
-				if err != nil {
-					return nil, diag.Diagnostics{
-						diag.NewErrorDiagnostic(
-							fmt.Sprintf("Failed to build poller for %d-th check (api)", i),
-							err.Error(),
-						),
-					}
-				}
-				if err := p.PollUntilDone(ctx, c); err != nil {
-					return nil, diag.Diagnostics{
-						diag.NewErrorDiagnostic(
-							fmt.Sprintf("Pre-checking %d-th check (api) failure", i),
-							err.Error(),
-						),
-					}
-				}
-			case !check.Mutex.IsNull():
-				key := check.Mutex.ValueString()
-				if err := locks.Lock(ctx, key); err != nil {
-					return nil, diag.Diagnostics{
-						diag.NewErrorDiagnostic(
-							fmt.Sprintf("Pre-checking %d-th check (mutex) failure", i),
-							err.Error(),
-						),
-					}
-				}
-				lockedNames = append(lockedNames, key)
+	for i, check := range checks {
+		switch {
+		case !check.Api.IsNull():
+			var d precheckDataApi
+			if diags := check.Api.As(ctx, &d, basetypes.ObjectAsOptions{}); diags.HasError() {
+				return nil, diags
 			}
+			opt, diags := apiOpt.ForPrecheck(ctx, defaultPath, defaultHeader, defaultQuery, d, body)
+			if diags.HasError() {
+				return nil, diags
+			}
+			p, err := client.NewPollableForPrecheck(*opt)
+			if err != nil {
+				return nil, diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						fmt.Sprintf("Failed to build poller for %d-th check (api)", i),
+						err.Error(),
+					),
+				}
+			}
+			if err := p.PollUntilDone(ctx, c); err != nil {
+				return nil, diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						fmt.Sprintf("Pre-checking %d-th check (api) failure", i),
+						err.Error(),
+					),
+				}
+			}
+		case !check.Mutex.IsNull():
+			key := check.Mutex.ValueString()
+			if err := locks.Lock(ctx, key); err != nil {
+				return nil, diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						fmt.Sprintf("Pre-checking %d-th check (mutex) failure", i),
+						err.Error(),
+					),
+				}
+			}
+			lockedNames = append(lockedNames, key)
 		}
 	}
+
 	return func() {
 		for i := len(lockedNames) - 1; i >= 0; i-- {
 			locks.Unlock(lockedNames[i])

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -130,7 +130,7 @@ func precheckAttribute(s string, pathIsRequired bool, suffixDesc string, statusL
 
 	var statusLocatorSuffixDesc string
 	if statusLocatorSupportParam {
-		statusLocatorSuffixDesc = " The `path` can contain parameter that reference the `body` (except for `create`). The `body` parameter comes from the state.output."
+		statusLocatorSuffixDesc = " The `path` can contain `$(body.x.y.z)` parameter that reference property from the `state.output`."
 	}
 
 	return schema.ListNestedAttribute{
@@ -226,8 +226,8 @@ func pollAttribute(s string) schema.SingleNestedAttribute {
 		Optional:            true,
 		Attributes: map[string]schema.Attribute{
 			"status_locator": schema.StringAttribute{
-				Description:         "Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the gjson syntax. The `path` can contain parameter that reference the `body`. Note that `body` parameter comes from the following: Create - response body, Read/Update/Delete - state.output.",
-				MarkdownDescription: "Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md). The `path` can contain parameter that reference the `body`. Note that `body` parameter comes from the following: Create - response body, Read/Update/Delete - state.output.",
+				Description:         "Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the gjson syntax. The `path` can contain `$(body.x.y.z)` parameter that reference property from either the response body (for `Create`, after selector), and `state.output` (for `Read`/`Update`/`Delete`).",
+				MarkdownDescription: "Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md). The `path` can contain `$(body.x.y.z)` parameter that reference property from either the response body (for `Create`, after selector), and `state.output` (for `Read`/`Update`/`Delete`).",
 				Required:            true,
 				Validators: []validator.String{
 					myvalidator.StringIsParsable("status_locator", func(s string) error {
@@ -349,7 +349,7 @@ func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 			"poll_update": pollAttribute("Update"),
 			"poll_delete": pollAttribute("Delete"),
 
-			"precheck_create": precheckAttribute("Create", true, "", true),
+			"precheck_create": precheckAttribute("Create", true, "", false),
 			"precheck_update": precheckAttribute("Update", false, "By default, the `id` of this resource is used.", true),
 			"precheck_delete": precheckAttribute("Delete", false, "By default, the `id` of this resource is used.", true),
 

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -114,10 +114,23 @@ func (r *Resource) Metadata(ctx context.Context, req resource.MetadataRequest, r
 	resp.TypeName = req.ProviderTypeName + "_resource"
 }
 
-func precheckAttribute(s string, pathIsRequired bool, suffixDesc string) schema.ListNestedAttribute {
+const paramFuncDescription = "Supported functions include: `escape` (URL path escape, by default applied), `unescape` (URL path unescape), `base` (filepath base), `url_path` (path segment of a URL), `trim_path` (trim `path`)."
+
+const pathDescription = "This can be a string literal, or combined by following params: path param: `$(path)` expanded to `path`, body param: `$(body.x.y.z)` expands to the `x.y.z` property of the API body. Especially for the body param, it can add a chain of functions (applied from left to right), in the form of `$f1.f2(body)`. " + paramFuncDescription
+
+func operationOverridableAttrDescription(attr string, opkind string) string {
+	return fmt.Sprintf("The %[1]s parameters that are applied to each %[2]s request. This overrides the `%[1]s` set in the resource block.", attr, opkind)
+}
+
+func precheckAttribute(s string, pathIsRequired bool, suffixDesc string, statusLocatorSupportParam bool) schema.ListNestedAttribute {
 	pathDesc := "The path used to query readiness, relative to the `base_url` of the provider."
 	if suffixDesc != "" {
 		pathDesc += " " + suffixDesc
+	}
+
+	var statusLocatorSuffixDesc string
+	if statusLocatorSupportParam {
+		statusLocatorSuffixDesc = " The `path` can contain parameter that reference the `body` (except for `create`). The `body` parameter comes from the state.output."
 	}
 
 	return schema.ListNestedAttribute{
@@ -142,13 +155,12 @@ func precheckAttribute(s string, pathIsRequired bool, suffixDesc string) schema.
 					Optional:            true,
 					Attributes: map[string]schema.Attribute{
 						"status_locator": schema.StringAttribute{
-							Description:         "Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the gjson syntax.",
-							MarkdownDescription: "Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).",
+							Description:         "Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the gjson syntax." + statusLocatorSuffixDesc,
+							MarkdownDescription: "Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md)." + statusLocatorSuffixDesc,
 							Required:            true,
 							Validators: []validator.String{
-								myvalidator.StringIsParsable("locator", func(s string) error {
-									_, err := parseLocator(s)
-									return err
+								myvalidator.StringIsParsable("status_locator", func(s string) error {
+									return validateLocator(s)
 								}),
 							},
 						},
@@ -214,13 +226,12 @@ func pollAttribute(s string) schema.SingleNestedAttribute {
 		Optional:            true,
 		Attributes: map[string]schema.Attribute{
 			"status_locator": schema.StringAttribute{
-				Description:         "Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the gjson syntax.",
-				MarkdownDescription: "Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md).",
+				Description:         "Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the gjson syntax. The `path` can contain parameter that reference the `body`. Note that `body` parameter comes from the following: Create - response body, Read/Update/Delete - state.output.",
+				MarkdownDescription: "Specifies how to discover the status property. The format is either `code` or `scope.path`, where `scope` can be either `header` or `body`, and the `path` is using the [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md). The `path` can contain parameter that reference the `body`. Note that `body` parameter comes from the following: Create - response body, Read/Update/Delete - state.output.",
 				Required:            true,
 				Validators: []validator.String{
-					myvalidator.StringIsParsable("locator", func(s string) error {
-						_, err := parseLocator(s)
-						return err
+					myvalidator.StringIsParsable("status_locator", func(s string) error {
+						return validateLocator(s)
 					}),
 				},
 			},
@@ -247,9 +258,8 @@ func pollAttribute(s string) schema.SingleNestedAttribute {
 				MarkdownDescription: "Specifies how to discover the polling url. The format can be one of `header.path` (use the property at `path` in response header), `body.path` (use the property at `path` in response body) or `exact.value` (use the exact `value`). When absent, the current operation's URL is used for polling, execpt `Create` where it fallbacks to use the resource id as the polling URL.",
 				Optional:            true,
 				Validators: []validator.String{
-					myvalidator.StringIsParsable("locator", func(s string) error {
-						_, err := parseLocator(s)
-						return err
+					myvalidator.StringIsParsable("url_locator", func(s string) error {
+						return validateLocator(s)
 					}),
 				},
 			},
@@ -268,14 +278,6 @@ func pollAttribute(s string) schema.SingleNestedAttribute {
 			},
 		},
 	}
-}
-
-const paramFuncDescription = "Supported functions include: `escape` (URL path escape, by default applied), `unescape` (URL path unescape), `base` (filepath base), `url_path` (path segment of a URL), `trim_path` (trim `path`)."
-
-const pathDescription = "This can be a string literal, or combined by following params: path param: `$(path)` expanded to `path`, body param: `$(body.x.y.z)` expands to the `x.y.z` property of the API body. Especially for the body param, it can add a chain of functions (applied from left to right), in the form of `$f1.f2(body)`. " + paramFuncDescription
-
-func operationOverridableAttrDescription(attr string, opkind string) string {
-	return fmt.Sprintf("The %[1]s parameters that are applied to each %[2]s request. This overrides the `%[1]s` set in the resource block.", attr, opkind)
 }
 
 func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -347,9 +349,9 @@ func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 			"poll_update": pollAttribute("Update"),
 			"poll_delete": pollAttribute("Delete"),
 
-			"precheck_create": precheckAttribute("Create", true, ""),
-			"precheck_update": precheckAttribute("Update", false, "By default, the `id` of this resource is used."),
-			"precheck_delete": precheckAttribute("Delete", false, "By default, the `id` of this resource is used."),
+			"precheck_create": precheckAttribute("Create", true, "", true),
+			"precheck_update": precheckAttribute("Update", false, "By default, the `id` of this resource is used.", true),
+			"precheck_delete": precheckAttribute("Delete", false, "By default, the `id` of this resource is used.", true),
 
 			"create_method": schema.StringAttribute{
 				Description:         "The method used to create the resource. Possible values are `PUT`, `POST` and `PATCH`. This overrides the `create_method` set in the provider block (defaults to POST).",
@@ -602,14 +604,15 @@ func (r *Resource) Configure(ctx context.Context, req resource.ConfigureRequest,
 }
 
 func (r Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	c := r.p.client
+	c.SetLoggerContext(ctx)
+
 	var plan resourceData
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if diags.HasError() {
 		return
 	}
-
-	c := r.p.client
 
 	opt, diags := r.p.apiOpt.ForResourceCreate(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -641,12 +644,14 @@ func (r Resource) Create(ctx context.Context, req resource.CreateRequest, resp *
 	}
 
 	// Precheck
-	unlockFunc, diags := precheck(ctx, c, r.p.apiOpt, "", opt.Header, opt.Query, plan.PrecheckCreate)
-	if diags.HasError() {
-		resp.Diagnostics.Append(diags...)
-		return
+	if !plan.PrecheckCreate.IsNull() {
+		unlockFunc, diags := precheck(ctx, c, r.p.apiOpt, "", opt.Header, opt.Query, plan.PrecheckCreate, basetypes.NewDynamicNull())
+		if diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
+		}
+		defer unlockFunc()
 	}
-	defer unlockFunc()
 
 	// Create the resource
 	b, err := dynamic.ToJSON(plan.Body)
@@ -729,7 +734,7 @@ func (r Resource) Create(ctx context.Context, req resource.CreateRequest, resp *
 			resp.Diagnostics.Append(diags...)
 			return
 		}
-		opt, diags := r.p.apiOpt.ForPoll(ctx, opt.Header, opt.Query, d)
+		opt, diags := r.p.apiOpt.ForPoll(ctx, opt.Header, opt.Query, d, output)
 		if diags.HasError() {
 			resp.Diagnostics.Append(diags...)
 			return
@@ -773,18 +778,19 @@ func (r Resource) Create(ctx context.Context, req resource.CreateRequest, resp *
 }
 
 func (r Resource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	r.p.client.SetLoggerContext(ctx)
 	r.read(ctx, req, resp, true)
 }
 
 func (r Resource) read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse, updateBody bool) {
+	c := r.p.client
+
 	var state resourceData
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if diags.HasError() {
 		return
 	}
-
-	c := r.p.client
 
 	opt, diags := r.p.apiOpt.ForResourceRead(ctx, state)
 	resp.Diagnostics.Append(diags...)
@@ -923,6 +929,9 @@ func (r Resource) read(ctx context.Context, req resource.ReadRequest, resp *reso
 }
 
 func (r Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	c := r.p.client
+	c.SetLoggerContext(ctx)
+
 	var state resourceData
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -940,8 +949,6 @@ func (r Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *
 	// Temporarily set the output here, so that the Read at the end can
 	// expand the `$(body)` parameters.
 	plan.Output = state.Output
-
-	c := r.p.client
 
 	opt, diags := r.p.apiOpt.ForResourceUpdate(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -969,12 +976,14 @@ func (r Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *
 	// Invoke API to Update the resource only when there are changes in the body (regardless of the TF type diff).
 	if string(stateBody) != string(planBody) {
 		// Precheck
-		unlockFunc, diags := precheck(ctx, c, r.p.apiOpt, state.ID.ValueString(), opt.Header, opt.Query, plan.PrecheckUpdate)
-		if diags.HasError() {
-			resp.Diagnostics.Append(diags...)
-			return
+		if !plan.PrecheckUpdate.IsNull() {
+			unlockFunc, diags := precheck(ctx, c, r.p.apiOpt, state.ID.ValueString(), opt.Header, opt.Query, plan.PrecheckUpdate, state.Output)
+			if diags.HasError() {
+				resp.Diagnostics.Append(diags...)
+				return
+			}
+			defer unlockFunc()
 		}
-		defer unlockFunc()
 
 		if opt.Method == "PATCH" && !opt.MergePatchDisabled {
 			stateBodyJSON, err := dynamic.ToJSON(state.Body)
@@ -1039,7 +1048,8 @@ func (r Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *
 				resp.Diagnostics.Append(diags...)
 				return
 			}
-			opt, diags := r.p.apiOpt.ForPoll(ctx, opt.Header, opt.Query, d)
+
+			opt, diags := r.p.apiOpt.ForPoll(ctx, opt.Header, opt.Query, d, state.Output)
 			if diags.HasError() {
 				resp.Diagnostics.Append(diags...)
 				return
@@ -1085,14 +1095,15 @@ func (r Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *
 }
 
 func (r Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	c := r.p.client
+	c.SetLoggerContext(ctx)
+
 	var state resourceData
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if diags.HasError() {
 		return
 	}
-
-	c := r.p.client
 
 	opt, diags := r.p.apiOpt.ForResourceDelete(ctx, state)
 	resp.Diagnostics.Append(diags...)
@@ -1101,12 +1112,14 @@ func (r Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *
 	}
 
 	// Precheck
-	unlockFunc, diags := precheck(ctx, c, r.p.apiOpt, state.ID.ValueString(), opt.Header, opt.Query, state.PrecheckDelete)
-	if diags.HasError() {
-		resp.Diagnostics.Append(diags...)
-		return
+	if !state.PrecheckDelete.IsNull() {
+		unlockFunc, diags := precheck(ctx, c, r.p.apiOpt, state.ID.ValueString(), opt.Header, opt.Query, state.PrecheckDelete, state.Output)
+		if diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
+		}
+		defer unlockFunc()
 	}
-	defer unlockFunc()
 
 	path := state.ID.ValueString()
 	if !state.DeletePath.IsNull() {
@@ -1155,7 +1168,7 @@ func (r Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *
 			resp.Diagnostics.Append(diags...)
 			return
 		}
-		opt, diags := r.p.apiOpt.ForPoll(ctx, opt.Header, opt.Query, d)
+		opt, diags := r.p.apiOpt.ForPoll(ctx, opt.Header, opt.Query, d, state.Output)
 		if diags.HasError() {
 			resp.Diagnostics.Append(diags...)
 			return

--- a/internal/provider/resource_azure_test.go
+++ b/internal/provider/resource_azure_test.go
@@ -326,7 +326,8 @@ func TestOperationResource_Azure_GetToken(t *testing.T) {
 
 func (d azureData) CheckDestroy(addr string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		c, err := client.New(context.TODO(), d.url, &client.BuildOption{
+		ctx := context.TODO()
+		c, err := client.New(ctx, d.url, &client.BuildOption{
 			Security: client.OAuth2ClientCredentialOption{
 				ClientId:     d.clientId,
 				ClientSecret: d.clientSecret,
@@ -339,10 +340,12 @@ func (d azureData) CheckDestroy(addr string) func(*terraform.State) error {
 		if err != nil {
 			return err
 		}
+		c.SetLoggerContext(ctx)
+
 		resource := s.RootModule().Resources[addr]
 		if resource != nil {
 			ver := resource.Primary.Attributes["query.api-version.0"]
-			resp, err := c.Read(context.TODO(), resource.Primary.ID, client.ReadOption{Query: map[string][]string{"api-version": {ver}}})
+			resp, err := c.Read(ctx, resource.Primary.ID, client.ReadOption{Query: map[string][]string{"api-version": {ver}}})
 			if err != nil {
 				return fmt.Errorf("reading %s: %v", addr, err)
 			}

--- a/internal/provider/resource_code_server_test.go
+++ b/internal/provider/resource_code_server_test.go
@@ -250,15 +250,17 @@ func TestResource_CodeServer_HeaderQuery(t *testing.T) {
 
 func (d codeServerData) CheckDestroy(url, addr string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
+		ctx := context.TODO()
 		c, err := client.New(context.TODO(), url, nil)
 		if err != nil {
 			return err
 		}
+		c.SetLoggerContext(ctx)
 		for key, resource := range s.RootModule().Resources {
 			if key != addr {
 				continue
 			}
-			resp, err := c.Read(context.TODO(), resource.Primary.ID, client.ReadOption{})
+			resp, err := c.Read(ctx, resource.Primary.ID, client.ReadOption{})
 			if err != nil {
 				return fmt.Errorf("reading %s: %v", addr, err)
 			}

--- a/internal/provider/resource_msgraph_test.go
+++ b/internal/provider/resource_msgraph_test.go
@@ -106,7 +106,8 @@ func TestResource_MsGraph_User(t *testing.T) {
 
 func (d msgraphData) CheckDestroy(addr string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		c, err := client.New(context.TODO(), d.url, &client.BuildOption{
+		ctx := context.TODO()
+		c, err := client.New(ctx, d.url, &client.BuildOption{
 			Security: client.OAuth2ClientCredentialOption{
 				ClientId:     d.clientId,
 				ClientSecret: d.clientSecret,
@@ -119,9 +120,10 @@ func (d msgraphData) CheckDestroy(addr string) func(*terraform.State) error {
 		if err != nil {
 			return err
 		}
+		c.SetLoggerContext(ctx)
 		resource := s.RootModule().Resources[addr]
 		if resource != nil {
-			resp, err := c.Read(context.TODO(), resource.Primary.ID, client.ReadOption{})
+			resp, err := c.Read(ctx, resource.Primary.ID, client.ReadOption{})
 			if err != nil {
 				return fmt.Errorf("reading %s: %v", addr, err)
 			}


### PR DESCRIPTION
This PR adds support of `$(body)` parameter for the followings:

- `restful_operation`:
  - `precheck_delete.api.status_locator`: The `body` comes from the TF state's `output`
  - `poll.status_locator`: The `body` comes from the operation's response
  - `poll_delete.status_locator`: The `body` comes from the TF state's `output`

- `restful_resource`:
  - `precheck_[update|delete].api.status_locator`: The `body` comes from the TF state's `output`
  - `poll_create.status_locator`: The `body` comes from the create response (after `create_selector` applied)
  - `poll_[update|delete].status_locator`: The `body` comes from the TF state's `output`

Fix #121