### PR TITLE
Expand body now supports `body` to be valid json (instead of string only)

### DIFF
--- a/internal/exparam/expand_body.go
+++ b/internal/exparam/expand_body.go
@@ -1,39 +1,36 @@
 package exparam
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/tidwall/gjson"
 )
 
-// Expand expands params of "$(body.x.y.z)" in the expression.
+// ExpandBody expands params of "$(body[.x.y.z])" in the expression.
 //
 // The param can be prefixed by a chain of functions.
 // The form is like: $f1.f2(body.x.y.z)
-func Expand(expr string, body []byte) (string, error) {
+func ExpandBody(expr string, body []byte) (string, error) {
 	out := expr
 	ff := FuncFactory{}.Build()
 
 	matches := Pattern.FindAllStringSubmatch(out, -1)
 
 	for _, match := range matches {
-		var ts string
+		var jp string
 		if match[2] == "body" {
-			if err := json.Unmarshal(body, &ts); err != nil {
-				return "", fmt.Errorf(`"body" expects type of string, but failed to unmarshal as a string: %v`, err)
-			}
+			jp = "@this"
 		} else if strings.HasPrefix(match[2], "body.") {
-			jsonPath := strings.TrimPrefix(match[2], "body.")
-			prop := gjson.GetBytes(body, jsonPath)
-			if !prop.Exists() {
-				return "", fmt.Errorf("no property found at path %q in the body", jsonPath)
-			}
-			ts = prop.String()
+			jp = strings.TrimPrefix(match[2], "body.")
 		} else {
 			return "", fmt.Errorf("invalid match: %s", match[0])
 		}
+		prop := gjson.GetBytes(body, jp)
+		if !prop.Exists() {
+			return "", fmt.Errorf("no property found at path %q in the body", jp)
+		}
+		ts := prop.String()
 
 		// Apply functions if any
 		fs := []Func{}

--- a/internal/exparam/expand_body_or_path_test.go
+++ b/internal/exparam/expand_body_or_path_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuildPath(t *testing.T) {
+func TestExpandBodyOrPath(t *testing.T) {
 	cases := []struct {
 		name    string
 		pattern string
@@ -100,7 +100,7 @@ func TestBuildPath(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, err := ExpandWithPath(tt.pattern, tt.path, []byte(tt.body))
+			actual, err := ExpandBodyOrPath(tt.pattern, tt.path, []byte(tt.body))
 			if tt.err != "" {
 				require.ErrorContains(t, err, tt.err)
 				return

--- a/internal/exparam/expand_body_test.go
+++ b/internal/exparam/expand_body_test.go
@@ -1,0 +1,67 @@
+package exparam_test
+
+import (
+	"testing"
+
+	"github.com/magodo/terraform-provider-restful/internal/exparam"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpand(t *testing.T) {
+	cases := []struct {
+		name    string
+		expr    string
+		body    string
+		expect  string
+		isError bool
+	}{
+		{
+			name:   "$(body) is a string",
+			expr:   "$(body)",
+			body:   `"abc"`,
+			expect: "abc",
+		},
+		{
+			name:   "$(body) is a number",
+			expr:   "$(body)",
+			body:   "123",
+			expect: "123",
+		},
+		{
+			name:   "$(body) is an object",
+			expr:   "$(body)",
+			body:   `{"foo": 123}`,
+			expect: `{"foo": 123}`,
+		},
+		{
+			name:   "$(body.a) is a string",
+			expr:   "$(body.a)",
+			body:   `{"a": "abc"}`,
+			expect: "abc",
+		},
+		{
+			name:   "$(body.a) is a number",
+			expr:   "$(body.a)",
+			body:   `{"a": 123}`,
+			expect: "123",
+		},
+		{
+			name:   "$(body.a) is an object",
+			expr:   "$(body.a)",
+			body:   `{"a": {"foo": 123}}`,
+			expect: `{"foo": 123}`,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := exparam.ExpandBody(tt.expr, []byte(tt.body))
+			if tt.isError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, actual)
+		})
+	}
+}

--- a/internal/provider/ephemeral_resource.go
+++ b/internal/provider/ephemeral_resource.go
@@ -355,7 +355,7 @@ func (e *EphemeralResource) Open(ctx context.Context, req ephemeral.OpenRequest,
 
 	// Set Renew and Close, if any
 	if !config.RenewMethod.IsNull() {
-		path, err := exparam.ExpandWithPath(config.RenewPath.ValueString(), config.Path.ValueString(), response.Body())
+		path, err := exparam.ExpandBodyOrPath(config.RenewPath.ValueString(), config.Path.ValueString(), response.Body())
 		if err != nil {
 			resp.Diagnostics.AddError(
 				fmt.Sprintf("Failed to build the path for renew the resource"),
@@ -387,7 +387,7 @@ func (e *EphemeralResource) Open(ctx context.Context, req ephemeral.OpenRequest,
 	}
 
 	if !config.CloseMethod.IsNull() {
-		path, err := exparam.ExpandWithPath(config.ClosePath.ValueString(), config.Path.ValueString(), response.Body())
+		path, err := exparam.ExpandBodyOrPath(config.ClosePath.ValueString(), config.Path.ValueString(), response.Body())
 		if err != nil {
 			resp.Diagnostics.AddError(
 				fmt.Sprintf("Failed to build the path for renew the resource"),

--- a/internal/provider/operation_resource.go
+++ b/internal/provider/operation_resource.go
@@ -265,7 +265,7 @@ func (r *OperationResource) createOrUpdate(ctx context.Context, tfplan tfsdk.Pla
 
 	resourceId := plan.Path.ValueString()
 	if !plan.IdBuilder.IsNull() {
-		resourceId, err = exparam.ExpandWithPath(plan.IdBuilder.ValueString(), plan.Path.ValueString(), response.Body())
+		resourceId, err = exparam.ExpandBodyOrPath(plan.IdBuilder.ValueString(), plan.Path.ValueString(), response.Body())
 		if err != nil {
 			diagnostics.AddError(
 				fmt.Sprintf("Failed to build the id for this resource"),
@@ -426,7 +426,7 @@ func (r *OperationResource) Delete(ctx context.Context, req resource.DeleteReque
 			)
 			return
 		}
-		path, err = exparam.ExpandWithPath(state.DeletePath.ValueString(), state.Path.ValueString(), body)
+		path, err = exparam.ExpandBodyOrPath(state.DeletePath.ValueString(), state.Path.ValueString(), body)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				fmt.Sprintf("Failed to build the path for deleting the operation resource"),

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -741,7 +741,7 @@ func (r Resource) Create(ctx context.Context, req resource.CreateRequest, resp *
 	// Construct the resource id, which is used as the path to read the resource later on. By default, it is the same as the "path", unless "read_path" is specified.
 	resourceId := plan.Path.ValueString()
 	if !plan.ReadPath.IsNull() {
-		resourceId, err = exparam.ExpandWithPath(plan.ReadPath.ValueString(), plan.Path.ValueString(), b)
+		resourceId, err = exparam.ExpandBodyOrPath(plan.ReadPath.ValueString(), plan.Path.ValueString(), b)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				fmt.Sprintf("Failed to build the path for reading the resource"),
@@ -878,7 +878,7 @@ func (r Resource) read(ctx context.Context, req resource.ReadRequest, resp *reso
 			)
 			return
 		}
-		sel, err = exparam.Expand(sel, stateOutput)
+		sel, err = exparam.ExpandBody(sel, stateOutput)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Read failure",
@@ -897,11 +897,11 @@ func (r Resource) read(ctx context.Context, req resource.ReadRequest, resp *reso
 	}
 
 	if tpl := state.ReadResponseTemplate.ValueString(); tpl != "" {
-		sb, err := exparam.Expand(tpl, b)
+		sb, err := exparam.ExpandBody(tpl, b)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Read failure",
-				fmt.Sprintf("Failed to expand the read response template selector: %v", err),
+				fmt.Sprintf("Failed to expand the read response template: %v", err),
 			)
 			return
 		}
@@ -1092,7 +1092,7 @@ func (r Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *
 			}
 			planBodyStr := string(planBody)
 			for i, patch := range patches {
-				pv, err := exparam.Expand(patch.RawJSON.ValueString(), stateOutput)
+				pv, err := exparam.ExpandBody(patch.RawJSON.ValueString(), stateOutput)
 				if err != nil {
 					resp.Diagnostics.AddError(
 						fmt.Sprintf("Failed to expand the %d-th patch for expression params", i),
@@ -1123,7 +1123,7 @@ func (r Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *
 				)
 				return
 			}
-			path, err = exparam.ExpandWithPath(plan.UpdatePath.ValueString(), plan.Path.ValueString(), output)
+			path, err = exparam.ExpandBodyOrPath(plan.UpdatePath.ValueString(), plan.Path.ValueString(), output)
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"Failed to build the path for updating the resource",
@@ -1241,7 +1241,7 @@ func (r Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *
 			)
 			return
 		}
-		path, err = exparam.ExpandWithPath(state.DeletePath.ValueString(), state.Path.ValueString(), output)
+		path, err = exparam.ExpandBodyOrPath(state.DeletePath.ValueString(), state.Path.ValueString(), output)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Failed to build the path for deleting the resource",

--- a/internal/provider/resource_code_server_test.go
+++ b/internal/provider/resource_code_server_test.go
@@ -262,7 +262,7 @@ func TestResource_CodeServer_ReadResponseTemplate(t *testing.T) {
 	})
 	mux.HandleFunc("GET /tests/1", func(w http.ResponseWriter, r *http.Request) {
 		// From https://github.com/magodo/terraform-provider-restful/issues/130
-		b, _ := json.Marshal(`[
+		b := []byte(`[
    {
       "property_name": "system",
       "value": "testing-system"

--- a/internal/provider/value_locator.go
+++ b/internal/provider/value_locator.go
@@ -42,13 +42,13 @@ func expandValueLocatorWithParam(locator string, body []byte) (client.ValueLocat
 	case "exact":
 		return client.ExactLocator(r), nil
 	case "header":
-		rr, err := exparam.Expand(r, body)
+		rr, err := exparam.ExpandBody(r, body)
 		if err != nil {
 			return nil, fmt.Errorf("expand param of %q: %v", r, err)
 		}
 		return client.HeaderLocator(rr), nil
 	case "body":
-		rr, err := exparam.Expand(r, body)
+		rr, err := exparam.ExpandBody(r, body)
 		if err != nil {
 			return nil, fmt.Errorf("expand param of %q: %v", r, err)
 		}


### PR DESCRIPTION
The parmeter expand function previously supports:

- `$(body)`: Whilst this has to be a json string
- `$(body.x)`: This can be any valid json, and the result is a string representation of that value. E.g. `foo` for `"foo"` (string), `123` for 123 (number).

This PR extends the `$(body)` to behave the same as `$(body.x)`.