### PR TITLE
Ephemeral `restful_resource` and `restful_operation` supports `body` exparam in `header` and `query`

### DIFF
--- a/internal/exparam/expand_body.go
+++ b/internal/exparam/expand_body.go
@@ -12,11 +12,13 @@ import (
 // The param can be prefixed by a chain of functions.
 // The form is like: $f1.f2(body.x.y.z)
 func ExpandBody(expr string, body []byte) (string, error) {
+	if len(body) == 0 {
+		return expr, nil
+	}
+
 	out := expr
 	ff := FuncFactory{}.Build()
-
 	matches := Pattern.FindAllStringSubmatch(out, -1)
-
 	for _, match := range matches {
 		var jp string
 		if match[2] == "body" {

--- a/internal/provider/api_option.go
+++ b/internal/provider/api_option.go
@@ -85,11 +85,11 @@ func (opt apiOption) ForDataSourceRead(ctx context.Context, d dataSourceData) (*
 	return &out, nil
 }
 
-func (opt apiOption) ForOperation(ctx context.Context, method basetypes.StringValue, defQuery, defHeader, ovQuery, ovHeader basetypes.MapValue) (*client.OperationOption, diag.Diagnostics) {
+func (opt apiOption) ForOperation(ctx context.Context, method basetypes.StringValue, defQuery, defHeader, ovQuery, ovHeader basetypes.MapValue, body []byte) (*client.OperationOption, diag.Diagnostics) {
 	out := client.OperationOption{
 		Method: method.ValueString(),
-		Query:  opt.Query.Clone().TakeOrSelf(ctx, defQuery).TakeOrSelf(ctx, ovQuery),
-		Header: opt.Header.Clone().TakeOrSelf(ctx, defHeader).TakeOrSelf(ctx, ovHeader),
+		Query:  opt.Query.Clone().TakeOrSelf(ctx, defQuery).TakeWithExparamOrSelf(ctx, ovQuery, body),
+		Header: opt.Header.Clone().TakeOrSelf(ctx, defHeader).TakeWithExparamOrSelf(ctx, ovHeader, body),
 	}
 
 	return &out, nil

--- a/internal/provider/ephemeral_resource_private_data.go
+++ b/internal/provider/ephemeral_resource_private_data.go
@@ -24,6 +24,8 @@ type ephemeralResourcePrivateData struct {
 	ExpiryType    types.String
 	ExpiryLocator types.String
 	ExpiryUnit    types.String
+
+	Output types.Dynamic
 }
 
 type ephemeralResourcePrivateDataGo struct {
@@ -39,6 +41,8 @@ type ephemeralResourcePrivateDataGo struct {
 	ExpiryType    string `json:"expiry_type,omitempty"`
 	ExpiryLocator string `json:"expiry_locator,omitempty"`
 	ExpiryUnit    string `json:"expiry_unit,omitempty"`
+
+	Output []byte `json:"output,omitempty"`
 }
 
 func (d ephemeralResourcePrivateData) MarshalJSON() ([]byte, error) {
@@ -68,6 +72,11 @@ func (d ephemeralResourcePrivateData) MarshalJSON() ([]byte, error) {
 	dg.Query, err = queryToGo(d.Query)
 	if err != nil {
 		return nil, err
+	}
+
+	dg.Output, err = dynamic.ToJSON(d.Output)
+	if err != nil {
+		return nil, fmt.Errorf("convert dynamic output to json: %v", err)
 	}
 
 	return json.Marshal(dg)
@@ -130,6 +139,16 @@ func (d *ephemeralResourcePrivateData) UnmarshalJSON(b []byte) error {
 		expiryUnit = types.StringValue(dg.ExpiryUnit)
 	}
 	d.ExpiryUnit = expiryUnit
+
+	output := types.DynamicNull()
+	if len(dg.Output) != 0 {
+		var err error
+		output, err = dynamic.FromJSONImplied(dg.Output)
+		if err != nil {
+			return fmt.Errorf("convert dynamic output from json failed: %v", err)
+		}
+	}
+	d.Output = output
 
 	return nil
 }


### PR DESCRIPTION
Supports `body` exparam for the following attributes:

- `restful_operation`: `delete_header` and `delete_query`
- Ephemeral `restful_resource`: `(renew|close)_header` and `(renew|close)_query`

Fix #147