### PR TITLE
fix: improper header definition for header in import

### DIFF
--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -1501,7 +1501,7 @@ type importSpec struct {
 	Query *url.Values `json:"query"`
 
 	// Header is only required when it is mandatory for reading the resource.
-	Header *url.Values `json:"header"`
+	Header map[string]string `json:"header"`
 
 	// Body represents the properties expected to be managed and tracked by Terraform. The value of these properties can be null as a place holder.
 	// When absent, all the response payload read wil be set to `body`.


### PR DESCRIPTION
This simple patch fix type for header field in import , to match schema