### PR TITLE
`restful_resource` - Support `post_create_read`

### DIFF
--- a/docs/resources/operation.md
+++ b/docs/resources/operation.md
@@ -75,7 +75,7 @@ Optional:
 
 - `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second. Defaults to `10`.
 - `header` (Map of String) The header parameters. This overrides the `header` set in the resource block.
-- `url_locator` (String) Specifies how to discover the polling url. The format can be one of `header.path` (use the property at `path` in response header), `body.path` (use the property at `path` in response body) or `exact.value` (use the exact `value`). When absent, the current operation's URL is used for polling, execpt `Create` where it fallbacks to use the resource id as the polling URL.
+- `url_locator` (String) Specifies how to discover the polling url. The format can be one of `header.path` (use the property at `path` in response header), `body.path` (use the property at `path` in response body) or `exact.value` (use the exact `value`). When absent, the current operation's URL is used for polling, execpt `Create` where it fallbacks to use the path constructed by the `read_path` as the polling URL.
 
 <a id="nestedatt--poll--status"></a>
 ### Nested Schema for `poll.status`
@@ -102,7 +102,7 @@ Optional:
 
 - `default_delay_sec` (Number) The interval between two pollings if there is no `Retry-After` in the response header, in second. Defaults to `10`.
 - `header` (Map of String) The header parameters. This overrides the `header` set in the resource block.
-- `url_locator` (String) Specifies how to discover the polling url. The format can be one of `header.path` (use the property at `path` in response header), `body.path` (use the property at `path` in response body) or `exact.value` (use the exact `value`). When absent, the current operation's URL is used for polling, execpt `Create` where it fallbacks to use the resource id as the polling URL.
+- `url_locator` (String) Specifies how to discover the polling url. The format can be one of `header.path` (use the property at `path` in response header), `body.path` (use the property at `path` in response body) or `exact.value` (use the exact `value`). When absent, the current operation's URL is used for polling, execpt `Create` where it fallbacks to use the path constructed by the `read_path` as the polling URL.
 
 <a id="nestedatt--poll_delete--status"></a>
 ### Nested Schema for `poll_delete.status`

--- a/examples/usecases/ado/project/main.tf
+++ b/examples/usecases/ado/project/main.tf
@@ -1,0 +1,80 @@
+terraform {
+  required_providers {
+    restful = {
+      source = "magodo/restful"
+    }
+  }
+}
+
+variable "pat" {
+  type = string
+}
+
+variable "host" {
+  type = string
+}
+
+provider "restful" {
+  base_url = var.host
+  security = {
+    http = {
+      basic = {
+        username = ""
+        password = var.pat
+      }
+    }
+  }
+}
+
+data "restful_resource" "process" {
+  id = "_apis/process/processes"
+  method = "GET"
+  header = {
+    "api-version": "7.2-preview"
+  }
+  selector = "value.#(isDefault==true)"
+}
+
+locals {
+  poll = {
+    url_locator = "body.url"
+    status_locator = "body.status"
+    status = {
+      success = "succeeded"
+      pending = ["inProgress", "queued"]
+    }
+    default_delay_sec = "3"
+  }
+}
+
+resource "restful_resource" "project" {
+  path = "_apis/projects"
+  read_path = "_apis/projects/$(body.id)"
+  update_method = "PATCH"
+  query = {
+    api-version = ["7.2-preview"]
+  }
+  post_create_read = {
+    path = "_apis/projects/restful"
+  }
+  poll_create = local.poll
+  poll_update = local.poll
+  poll_delete = local.poll
+  body = {
+    name = "restful"
+    description = "Created by the restful provider"
+    visibility = "private"
+    capabilities = {
+      processTemplate = {
+        templateTypeId = data.restful_resource.process.output.id
+      }
+      versioncontrol = {
+        sourceControlType = "git"
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [body.capabilities]
+  }
+}

--- a/internal/client/async.go
+++ b/internal/client/async.go
@@ -111,6 +111,8 @@ func NewPollableForPoll(resp resty.Response, opt PollOption) (*Pollable, error) 
 			return nil, fmt.Errorf("invalid Retry-After value in the initiated response: %s", dur)
 		}
 		p.InitDelay = d
+	} else {
+		p.InitDelay = opt.DefaultDelay
 	}
 
 	var rawURL string

--- a/internal/provider/api_option.go
+++ b/internal/provider/api_option.go
@@ -44,6 +44,15 @@ func (opt apiOption) ForResourceRead(ctx context.Context, d resourceData, body [
 	return &out, nil
 }
 
+func (opt apiOption) ForResourcePostCreateRead(ctx context.Context, d resourceData, pr postCreateRead, body []byte) (*client.ReadOption, diag.Diagnostics) {
+	out := client.ReadOption{
+		Query:  opt.Query.Clone().TakeOrSelf(ctx, d.Query).TakeWithExparamOrSelf(ctx, pr.Query, body),
+		Header: opt.Header.Clone().TakeOrSelf(ctx, d.Header).TakeWithExparamOrSelf(ctx, pr.Header, body),
+	}
+
+	return &out, nil
+}
+
 func (opt apiOption) ForResourceUpdate(ctx context.Context, d resourceData, body []byte) (*client.UpdateOption, diag.Diagnostics) {
 	out := client.UpdateOption{
 		Method:             opt.UpdateMethod,

--- a/internal/provider/operation_resource.go
+++ b/internal/provider/operation_resource.go
@@ -380,7 +380,7 @@ func (r *OperationResource) createOrUpdate(ctx context.Context, reqConfig tfsdk.
 		resourceId, err = exparam.ExpandBodyOrPath(plan.IdBuilder.ValueString(), plan.Path.ValueString(), response.Body())
 		if err != nil {
 			respDiags.AddError(
-				fmt.Sprintf("Failed to build the id for this resource"),
+				"Failed to build the id for this resource",
 				fmt.Sprintf("Can't build resource id with `id_builder`: %q, `path`: %q: %v", plan.IdBuilder.ValueString(), plan.Path.ValueString(), err),
 			)
 			return
@@ -500,16 +500,13 @@ func (r *OperationResource) createOrUpdate(ctx context.Context, reqConfig tfsdk.
 
 func (r *OperationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	r.createOrUpdate(ctx, req.Config, req.Plan, tfsdk.State{}, resp.Private, &resp.State, &resp.Diagnostics, true)
-	return
 }
 
 func (r *OperationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	r.createOrUpdate(ctx, req.Config, req.Plan, req.State, resp.Private, &resp.State, &resp.Diagnostics, false)
-	return
 }
 
 func (r *OperationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	return
 }
 
 func (r *OperationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -526,7 +523,7 @@ func (r *OperationResource) Delete(ctx context.Context, req resource.DeleteReque
 	output, err := dynamic.ToJSON(state.Output)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			fmt.Sprintf("Failed to build the path for deleting the operation resource"),
+			"Failed to build the path for deleting the operation resource",
 			fmt.Sprintf("Failed to marshal the output: %v", err),
 		)
 		return
@@ -559,7 +556,7 @@ func (r *OperationResource) Delete(ctx context.Context, req resource.DeleteReque
 		path, err = exparam.ExpandBodyOrPath(state.DeletePath.ValueString(), state.Path.ValueString(), output)
 		if err != nil {
 			resp.Diagnostics.AddError(
-				fmt.Sprintf("Failed to build the path for deleting the operation resource"),
+				"Failed to build the path for deleting the operation resource",
 				fmt.Sprintf("Can't build path with `delete_path`: %q, `path`: %q, `body`: %q, error: %v", state.DeletePath.ValueString(), state.Path.ValueString(), string(output), err),
 			)
 			return
@@ -619,6 +616,4 @@ func (r *OperationResource) Delete(ctx context.Context, req resource.DeleteReque
 			return
 		}
 	}
-
-	return
 }

--- a/internal/provider/resource_ado_test.go
+++ b/internal/provider/resource_ado_test.go
@@ -1,0 +1,198 @@
+package provider_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/magodo/terraform-provider-restful/internal/acceptance"
+	"github.com/magodo/terraform-provider-restful/internal/client"
+)
+
+const RESTFUL_ADO_PAT = "RESTFUL_ADO_PAT"
+const RESTFUL_ADO_URL = "RESTFUL_ADO_URL"
+
+type adoData struct {
+	pat     string
+	url     string
+	version string
+	rd      acceptance.Rd
+}
+
+func (d adoData) precheck(t *testing.T) {
+	if d.pat == "" {
+		t.Skipf("%q is not specified", RESTFUL_ADO_PAT)
+	}
+	if d.url == "" {
+		t.Skipf("%q is not specified", RESTFUL_ADO_URL)
+	}
+}
+
+func newAdoData() adoData {
+	return adoData{
+		pat:     os.Getenv(RESTFUL_ADO_PAT),
+		url:     os.Getenv(RESTFUL_ADO_URL),
+		version: "7.2-preview",
+		rd:      acceptance.NewRd(),
+	}
+}
+
+func TestResource_ADO_Project(t *testing.T) {
+	addr := "restful_resource.test"
+	d := newAdoData()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { d.precheck(t) },
+		CheckDestroy:             d.CheckDestroy(addr),
+		ProtoV6ProviderFactories: acceptance.ProviderFactory(),
+		Steps: []resource.TestStep{
+			{
+				Config: d.project("foo"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(addr, tfjsonpath.New("output").AtMapKey("id"), knownvalue.NotNull()),
+				},
+			},
+			{
+				ResourceName:      addr,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateIdFunc: d.projectImportStateIdFunc(addr),
+			},
+			{
+				Config: d.project("bar"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(addr, tfjsonpath.New("output").AtMapKey("id"), knownvalue.NotNull()),
+				},
+			},
+			{
+				ResourceName:      addr,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateIdFunc: d.projectImportStateIdFunc(addr),
+			},
+		},
+	})
+}
+
+func (d adoData) CheckDestroy(addr string) func(*terraform.State) error {
+	return func(s *terraform.State) error {
+		ctx := context.TODO()
+		c, err := client.New(ctx, d.url, &client.BuildOption{
+			Security: client.HTTPBasicOption{
+				Username: "",
+				Password: d.pat,
+			},
+		})
+		if err != nil {
+			return err
+		}
+		c.SetLoggerContext(ctx)
+		resource := s.RootModule().Resources[addr]
+		if resource != nil {
+			query := client.Query{"api-version": []string{d.version}}
+			resp, err := c.Read(ctx, resource.Primary.ID, client.ReadOption{Query: query})
+			if err != nil {
+				return fmt.Errorf("reading %s: %v", addr, err)
+			}
+			if resp.StatusCode() != http.StatusNotFound {
+				return fmt.Errorf("%s: still exists", addr)
+			}
+		}
+		return nil
+	}
+}
+
+func (d adoData) projectTemplate() string {
+	return fmt.Sprintf(`
+provider "restful" {
+  base_url = %q
+  security = {
+	http = {
+	  basic = {
+		username = ""
+		password = %q
+	  }
+	}
+  }
+}
+
+data "restful_resource" "process" {
+  id = "_apis/process/processes"
+  method = "GET"
+  header = {
+    "api-version": %q
+  }
+  selector = "value.#(isDefault==true)"
+}
+`, d.url, d.pat, d.version)
+}
+
+func (d adoData) project(name string) string {
+	return fmt.Sprintf(`
+%s
+
+locals {
+  poll = {
+    url_locator = "body.url"
+    status_locator = "body.status"
+    status = {
+      success = "succeeded"
+      pending = ["inProgress", "queued"]
+    }
+    default_delay_sec = "3"
+  }
+}
+
+resource "restful_resource" "test" {
+  path = "_apis/projects"
+  read_path = "_apis/projects/$(body.id)"
+  update_method = "PATCH"
+  query = {
+    api-version = ["7.2-preview"]
+  }
+  post_create_read = {
+    path = "_apis/projects/%s"
+  }
+  poll_create = local.poll
+  poll_update = local.poll
+  poll_delete = local.poll
+  body = {
+    name = "%s"
+    description = "Created by the restful provider"
+    visibility = "private"
+    capabilities = {
+      processTemplate = {
+        templateTypeId = data.restful_resource.process.output.id
+      }
+      versioncontrol = {
+        sourceControlType = "git"
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [body.capabilities]
+  }
+}
+`, d.projectTemplate(), name, name)
+}
+
+func (d adoData) projectImportStateIdFunc(addr string) func(s *terraform.State) (string, error) {
+	return func(s *terraform.State) (string, error) {
+		return fmt.Sprintf(`{
+"id": %q,
+"path": "/_apis/projects",
+"body": {
+  "name": null,
+  "description": null,
+  "visibility": null
+}
+}`, s.RootModule().Resources[addr].Primary.Attributes["id"]), nil
+	}
+}


### PR DESCRIPTION
`restful_resource` - Support `post_create_read`.

This introduces an additional read after creation (after polling, if any) for overriding the `$(body)` used for `read_path`, which was representing the response body of the initial create call. This is only meant to be used for APIs that only forms a resource id after the resource is completely created. One example is the AzureDevOps `project` API: A `project` is identified by a UUID, the user needs to create the project, polling the long running operation, then query the `project` by its (mutable) name, where it returns you the (immutable) UUID. This UUID is then used to continue manage this resource (reading/updating/deleting). The create response and polling response doesn't include that UUID (they only contains the UUID of the long running operation).

Check out the ADO example for the complete configuration.