### PR TITLE
Allow overriding the `content-type` via `header`

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -208,7 +208,9 @@ func (c *Client) Create(ctx context.Context, path string, body string, opt Creat
 	req := c.R().SetContext(ctx).SetBody(body)
 	req.SetQueryParamsFromValues(url.Values(opt.Query))
 	req.SetHeaders(opt.Header)
-	req = req.SetHeader("Content-Type", "application/json")
+	if req.Header.Get("content-type") == "" {
+		req = req.SetHeader("Content-Type", "application/json")
+	}
 
 	switch opt.Method {
 	case "POST":


### PR DESCRIPTION
Since the provider is heavily relying on the JSON format, there isn't an obvious way to support other formats like XML, etc. Instead, we just ensure users can specify other JSON variant MIME types via the `header`, which override the default `applications/json`.

Fix #4 