### PR TITLE
`restful_resource` - Set resource identity during Create/Update/Read (mutation allowed)

### DIFF
--- a/internal/provider/resource_jsonserver_test.go
+++ b/internal/provider/resource_jsonserver_test.go
@@ -57,6 +57,7 @@ func TestResource_JSONServer_Basic(t *testing.T) {
 				Config: d.basic("foo"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(addr, tfjsonpath.New("output").AtMapKey("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(addr, tfjsonpath.New("output").AtMapKey("foo"), knownvalue.StringExact("foo")),
 				},
 			},
 			{
@@ -98,6 +99,7 @@ func TestResource_JSONServer_Basic(t *testing.T) {
 				Config: d.basic("bar"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(addr, tfjsonpath.New("output").AtMapKey("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(addr, tfjsonpath.New("output").AtMapKey("foo"), knownvalue.StringExact("bar")),
 				},
 			},
 			{


### PR DESCRIPTION
This PR makes the `restful_resource` to set resource identity during Create/Update/Read (mutation allowed), which was only set during `Create`.

The reason to extend to `Read` is to allow the resources being created by the old version can be continuely managed by the new version of the provider, as otherwise the `terraform` will complain that a successful `Read` doesn't populate the resource identity.

The reason to extend to `Update` and allow mutation is because (nullified) `body` is part of the identity, which can be changed uring `Update`.

## Test

```shell
terraform-provider-restful on  read_identity via 🐹 v1.25.3 via 💠 default took 1m56s
💢 TF_ACC=1 go test -v -timeout=20h ./internal/provider
=== RUN   TestModifyJSON
=== RUN   TestModifyJSON/invalid_base
=== RUN   TestModifyJSON/invalid_body
=== RUN   TestModifyJSON/with_write_only_attrs
--- PASS: TestModifyJSON (0.00s)
    --- PASS: TestModifyJSON/invalid_base (0.00s)
    --- PASS: TestModifyJSON/invalid_body (0.00s)
    --- PASS: TestModifyJSON/with_write_only_attrs (0.00s)
=== RUN   TestGetUpdatedJSON
=== RUN   TestGetUpdatedJSON/simple_object
=== RUN   TestGetUpdatedJSON/nested_object
=== RUN   TestGetUpdatedJSON/simple_array
=== RUN   TestGetUpdatedJSON/simple_array_with_different_size
=== RUN   TestGetUpdatedJSON/complex_array
--- PASS: TestGetUpdatedJSON (0.00s)
    --- PASS: TestGetUpdatedJSON/simple_object (0.00s)
    --- PASS: TestGetUpdatedJSON/nested_object (0.00s)
    --- PASS: TestGetUpdatedJSON/simple_array (0.00s)
    --- PASS: TestGetUpdatedJSON/simple_array_with_different_size (0.00s)
    --- PASS: TestGetUpdatedJSON/complex_array (0.00s)
=== RUN   TestGetUpdatedJSONForImport
=== RUN   TestGetUpdatedJSONForImport/nil
=== RUN   TestGetUpdatedJSONForImport/simple_object
=== RUN   TestGetUpdatedJSONForImport/nested_object
=== RUN   TestGetUpdatedJSONForImport/nested_object_with_no_child_detail
=== RUN   TestGetUpdatedJSONForImport/0_sized_array_is_the_same_as_nil
=== RUN   TestGetUpdatedJSONForImport/0_sized_array_is_also_the_same_as_of_a_single_nil_element
=== RUN   TestGetUpdatedJSONForImport/more_than_one_element_in_array
=== RUN   TestGetUpdatedJSONForImport/complex_array
=== RUN   TestGetUpdatedJSONForImport/object_nesting_complex_array
--- PASS: TestGetUpdatedJSONForImport (0.00s)
    --- PASS: TestGetUpdatedJSONForImport/nil (0.00s)
    --- PASS: TestGetUpdatedJSONForImport/simple_object (0.00s)
    --- PASS: TestGetUpdatedJSONForImport/nested_object (0.00s)
    --- PASS: TestGetUpdatedJSONForImport/nested_object_with_no_child_detail (0.00s)
    --- PASS: TestGetUpdatedJSONForImport/0_sized_array_is_the_same_as_nil (0.00s)
    --- PASS: TestGetUpdatedJSONForImport/0_sized_array_is_also_the_same_as_of_a_single_nil_element (0.00s)
    --- PASS: TestGetUpdatedJSONForImport/more_than_one_element_in_array (0.00s)
    --- PASS: TestGetUpdatedJSONForImport/complex_array (0.00s)
    --- PASS: TestGetUpdatedJSONForImport/object_nesting_complex_array (0.00s)
=== RUN   TestFilterJSON
=== RUN   TestFilterJSON/invalid_body
=== RUN   TestFilterJSON/object_with_non_existed_attrs
=== RUN   TestFilterJSON/object_with_splat_addr
=== RUN   TestFilterJSON/array_with_non_existed_attrs
=== RUN   TestFilterJSON/array_with_key_addr
=== RUN   TestFilterJSON/filter_object
=== RUN   TestFilterJSON/filter_object_for_nothing
=== RUN   TestFilterJSON/filter_array
=== RUN   TestFilterJSON/filter_array_of_same_elements
=== RUN   TestFilterJSON/filter_array_nested_in_array
--- PASS: TestFilterJSON (0.00s)
    --- PASS: TestFilterJSON/invalid_body (0.00s)
    --- PASS: TestFilterJSON/object_with_non_existed_attrs (0.00s)
    --- PASS: TestFilterJSON/object_with_splat_addr (0.00s)
    --- PASS: TestFilterJSON/array_with_non_existed_attrs (0.00s)
    --- PASS: TestFilterJSON/array_with_key_addr (0.00s)
    --- PASS: TestFilterJSON/filter_object (0.00s)
    --- PASS: TestFilterJSON/filter_object_for_nothing (0.00s)
    --- PASS: TestFilterJSON/filter_array (0.00s)
    --- PASS: TestFilterJSON/filter_array_of_same_elements (0.00s)
    --- PASS: TestFilterJSON/filter_array_nested_in_array (0.00s)
=== RUN   TestMarshalEphemeralResourcePrivateData
=== RUN   TestMarshalEphemeralResourcePrivateData/all_set
=== RUN   TestMarshalEphemeralResourcePrivateData/only_method
--- PASS: TestMarshalEphemeralResourcePrivateData (0.00s)
    --- PASS: TestMarshalEphemeralResourcePrivateData/all_set (0.00s)
    --- PASS: TestMarshalEphemeralResourcePrivateData/only_method (0.00s)
=== RUN   TestUnMarshalEphemeralResourcePrivateData
=== RUN   TestUnMarshalEphemeralResourcePrivateData/all_set
=== RUN   TestUnMarshalEphemeralResourcePrivateData/only_method
--- PASS: TestUnMarshalEphemeralResourcePrivateData (0.00s)
    --- PASS: TestUnMarshalEphemeralResourcePrivateData/all_set (0.00s)
    --- PASS: TestUnMarshalEphemeralResourcePrivateData/only_method (0.00s)
=== RUN   TestDataSource_JSONServer_Basic
--- PASS: TestDataSource_JSONServer_Basic (0.32s)
=== RUN   TestDataSource_JSONServer_WithSelector
--- PASS: TestDataSource_JSONServer_WithSelector (0.31s)
=== RUN   TestDataSource_JSONServer_WithOutputAttrs
--- PASS: TestDataSource_JSONServer_WithOutputAttrs (0.32s)
=== RUN   TestDataSource_JSONServer_NotExists
--- PASS: TestDataSource_JSONServer_NotExists (0.22s)
=== RUN   TestDataSourceMTLS
--- PASS: TestDataSourceMTLS (2.31s)
=== RUN   TestEphemeral_CodeServer_basic
--- PASS: TestEphemeral_CodeServer_basic (0.26s)
=== RUN   TestEphemeral_CodeServer_complete
--- PASS: TestEphemeral_CodeServer_complete (2.56s)
=== RUN   TestEphemeral_CodeServer_HeaderQueryFromBody
--- PASS: TestEphemeral_CodeServer_HeaderQueryFromBody (0.19s)
=== RUN   TestListResource_JSONServer_Basic
--- PASS: TestListResource_JSONServer_Basic (0.39s)
=== RUN   TestOperationResource_Azure_Register_RP
=== PAUSE TestOperationResource_Azure_Register_RP
=== RUN   TestOperationResource_Azure_GetToken
=== PAUSE TestOperationResource_Azure_GetToken
=== RUN   TestOperation_CodeServer_Empty
--- PASS: TestOperation_CodeServer_Empty (0.26s)
=== RUN   TestOperation_CodeServer_idBuilder
--- PASS: TestOperation_CodeServer_idBuilder (10.25s)
=== RUN   TestOperation_CodeServer_HeaderQuery
--- PASS: TestOperation_CodeServer_HeaderQuery (0.26s)
=== RUN   TestOperation_CodeServer_HeaderQueryFromBody
--- PASS: TestOperation_CodeServer_HeaderQueryFromBody (0.27s)
=== RUN   TestOperation_JSONServer_Basic
--- PASS: TestOperation_JSONServer_Basic (0.26s)
=== RUN   TestOperation_JSONServer_withDelete
--- PASS: TestOperation_JSONServer_withDelete (0.70s)
=== RUN   TestOperation_JSONServer_statusLocatorParam
--- PASS: TestOperation_JSONServer_statusLocatorParam (10.29s)
=== RUN   TestOperation_JSONServer_EphemeralBodyOverlap
--- PASS: TestOperation_JSONServer_EphemeralBodyOverlap (0.07s)
=== RUN   TestOperation_JSONServer_EphemeralBody
--- PASS: TestOperation_JSONServer_EphemeralBody (0.84s)
=== RUN   TestOperation_JSONServer_MigrateV0ToV1
    operation_jsonserver_test.go:30: "RESTFUL_MIGRATE_TEST" is not specified
--- SKIP: TestOperation_JSONServer_MigrateV0ToV1 (0.00s)
=== RUN   TestResource_ADO_Project
=== PAUSE TestResource_ADO_Project
=== RUN   TestResource_Azure_ResourceGroup
=== PAUSE TestResource_Azure_ResourceGroup
=== RUN   TestResource_Azure_ResourceGroup_updatePath
=== PAUSE TestResource_Azure_ResourceGroup_updatePath
=== RUN   TestResource_Azure_VirtualNetwork
=== PAUSE TestResource_Azure_VirtualNetwork
=== RUN   TestResource_Azure_VirtualNetwork_Precheck
=== PAUSE TestResource_Azure_VirtualNetwork_Precheck
=== RUN   TestResource_Azure_VirtualNetwork_SimplePoll
=== PAUSE TestResource_Azure_VirtualNetwork_SimplePoll
=== RUN   TestResource_Azure_RouteTable_Precheck
=== PAUSE TestResource_Azure_RouteTable_Precheck
=== RUN   TestResource_CodeServer_ObjectArray
--- PASS: TestResource_CodeServer_ObjectArray (0.66s)
=== RUN   TestResource_CodeServer_CreateRetString
--- PASS: TestResource_CodeServer_CreateRetString (0.37s)
=== RUN   TestResource_CodeServer_RetFullURL
--- PASS: TestResource_CodeServer_RetFullURL (0.29s)
=== RUN   TestResource_CodeServer_HeaderQuery
--- PASS: TestResource_CodeServer_HeaderQuery (0.29s)
=== RUN   TestResource_CodeServer_HeaderQueryFromBody
--- PASS: TestResource_CodeServer_HeaderQueryFromBody (0.30s)
=== RUN   TestResource_CodeServer_ReadResponseTemplate
--- PASS: TestResource_CodeServer_ReadResponseTemplate (0.37s)
=== RUN   TestResource_CodeServer_DeleteMethodBody
--- PASS: TestResource_CodeServer_DeleteMethodBody (0.29s)
=== RUN   TestResource_CodeServer_DeleteMethodBodyRaw
--- PASS: TestResource_CodeServer_DeleteMethodBodyRaw (0.29s)
=== RUN   TestResource_JSONServer_Basic
--- PASS: TestResource_JSONServer_Basic (0.78s)
=== RUN   TestResource_JSONServer_PatchUpdate
--- PASS: TestResource_JSONServer_PatchUpdate (0.70s)
=== RUN   TestResource_JSONServer_FullPath
--- PASS: TestResource_JSONServer_FullPath (0.70s)
=== RUN   TestResource_JSONServer_OutputAttrs
--- PASS: TestResource_JSONServer_OutputAttrs (0.31s)
=== RUN   TestResource_JSONServer_ReadSelectorParam
--- PASS: TestResource_JSONServer_ReadSelectorParam (0.65s)
=== RUN   TestResource_JSONServer_StatusLocatorParam
--- PASS: TestResource_JSONServer_StatusLocatorParam (20.57s)
=== RUN   TestResource_JSONServer_UpdateBodyPatch
--- PASS: TestResource_JSONServer_UpdateBodyPatch (0.53s)
=== RUN   TestResource_JSONServer_EphemeralBodyOverlap
--- PASS: TestResource_JSONServer_EphemeralBodyOverlap (0.07s)
=== RUN   TestResource_JSONServer_EphemeralBody
--- PASS: TestResource_JSONServer_EphemeralBody (1.30s)
=== RUN   TestResource_JSONServer_MigrateV0ToV1
    resource_jsonserver_test.go:37: "RESTFUL_MIGRATE_TEST" is not specified
--- SKIP: TestResource_JSONServer_MigrateV0ToV1 (0.00s)
=== RUN   TestResource_MsGraph_User
=== PAUSE TestResource_MsGraph_User
=== RUN   TestSchemaValidation
--- PASS: TestSchemaValidation (0.00s)
=== CONT  TestOperationResource_Azure_Register_RP
=== CONT  TestResource_Azure_VirtualNetwork
=== CONT  TestResource_Azure_RouteTable_Precheck
=== CONT  TestResource_Azure_ResourceGroup_updatePath
=== CONT  TestResource_Azure_VirtualNetwork_SimplePoll
=== CONT  TestResource_Azure_ResourceGroup
=== CONT  TestResource_MsGraph_User
=== CONT  TestResource_ADO_Project
=== CONT  TestOperationResource_Azure_GetToken
=== CONT  TestResource_Azure_VirtualNetwork_Precheck
=== NAME  TestResource_ADO_Project
    resource_ado_test.go:31: "RESTFUL_ADO_PAT" is not specified
--- SKIP: TestResource_ADO_Project (0.00s)
--- PASS: TestOperationResource_Azure_GetToken (1.27s)
--- PASS: TestResource_MsGraph_User (9.74s)
--- PASS: TestResource_Azure_ResourceGroup (38.20s)
--- PASS: TestResource_Azure_ResourceGroup_updatePath (41.38s)
--- PASS: TestResource_Azure_VirtualNetwork_Precheck (64.93s)
--- PASS: TestResource_Azure_RouteTable_Precheck (66.47s)
--- PASS: TestResource_Azure_VirtualNetwork_SimplePoll (69.74s)
--- PASS: TestResource_Azure_VirtualNetwork (76.50s)
--- PASS: TestOperationResource_Azure_Register_RP (94.57s)
PASS
ok      github.com/magodo/terraform-provider-restful/internal/provider  153.134s
```