### PR TITLE
`restful_resource` - Supports `update_body_patches.*.removed` to remove values from the update body

### DIFF
--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -300,7 +300,11 @@ Optional:
 Required:
 
 - `path` (String) The path (in [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md)) to the attribute to [patch](https://github.com/tidwall/sjson?tab=readme-ov-file#set-a-value).
-- `raw_json` (String) The raw json used as the patch value. It can contain `$(body.x.y.z)` parameter that reference property from the `state.output`.
+
+Optional:
+
+- `raw_json` (String) The raw json used as the patch value. It can contain `$(body.x.y.z)` parameter that reference property from the `state.output`. Exactly one of `raw_json` and `removed` shall be specified.
+- `removed` (Boolean) Remove the value specified by `path` from the update body. Exactly one of `raw_json` and `removed` shall be specified
 
 ## Import
 


### PR DESCRIPTION
This PR adds support of `update_body_patches.*.removed` to remove values from the update body, for the `restful_resource`.

This is useful when some service doesn't allow certain fields in the `body` specified when calling the update API.

Fixes #159.