### PR TITLE
`restful_action`: support `ephemeral_body`

### DIFF
--- a/internal/provider/action_jsonserver_test.go
+++ b/internal/provider/action_jsonserver_test.go
@@ -51,6 +51,9 @@ resource "restful_resource" "test" {
   body = {
   	foo = "bar"
   }
+  ephemeral_body = {
+	x = "y"
+  }
   read_path = "$(path)/$(body.id)"
 
   lifecycle {


### PR DESCRIPTION
`restful_action` add support of `ephemeral_body` write-only attribute.