### PR TITLE
`restful_resource`: `update_body_patches` supports `path` to be empty to imply changes on the whole update body

### DIFF
--- a/docs/actions/action.md
+++ b/docs/actions/action.md
@@ -22,7 +22,10 @@ description: |-
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `body` (Dynamic) The payload for the `Invoke` call.
+- `ephemeral_body` (Dynamic, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The ephemeral (write-only) properties of the resource. This will be merge-patched to the `body` to construct the actual request body.
 - `header` (Map of String) The header parameters for the `Invoke` call. This overrides the `header` set in the provider block.
 - `poll` (Attributes) The polling option for the "Invoke" operation (see [below for nested schema](#nestedatt--poll))
 - `precheck` (Attributes List) An array of prechecks that need to pass prior to the "Invoke" operation. Exactly one of `mutex` or `api` should be specified. (see [below for nested schema](#nestedatt--precheck))

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -301,7 +301,7 @@ Optional:
 
 Required:
 
-- `path` (String) The path (in [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md)) to the attribute to [patch](https://github.com/tidwall/sjson?tab=readme-ov-file#set-a-value).
+- `path` (String) The path (in [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md)) to the attribute to [patch](https://github.com/tidwall/sjson?tab=readme-ov-file#set-a-value). Empty string means to patch (i.e. replace or remove) the whole update body.
 
 Optional:
 


### PR DESCRIPTION
Fix #170.

Instead there is another thought about #170 scenario: Instead of asking the user to compose the JSON patch, we shall do it for the users. We can extend the `merge_patch_disabled` attribute to `update_mode`, which can be:

- `json_patch`: Computing a JSON patch (rfc6902) based on the state `body` and planned `body`, make it as the request body of update. We can leverage the https://pkg.go.dev/github.com/wI2L/jsondiff to do this. Also we shall expose different options to the users per the API to allow the user to choose how to calculate the patch.
- `json_merge` Computing a JSON merge patch (rfc7386) to be as the request body of update.
- `none`: Simply use the planned `body` as the request body of update.

Whilst this requires more changes on both the provider and restful resource to deprecate the `merge_patch_disabled` and introduce the provider/resource-level new attributes `update_mode` and `json_patch_options`. Since there isn't a big demand on `json_patch` update body, I'll hold on implementing this.